### PR TITLE
Node selection logic tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ The `left` and `right` values should be from 0 to the width of the canvas in pix
 
 The `top` and `bottom` values should be from 0 to the height of the canvas in pixels.
 
-<a name="select_node_by_id" href="#select_node_by_id">#</a> graph.<b>selectNodeById</b>(<i>id</i>)
+<a name="select_node_by_id" href="#select_node_by_id">#</a> graph.<b>selectNodeById</b>(<i>id</i>, [<i>selectAdjacentNodes</i>])
 
-Select a node by <i>id</i>.
+Select a node by <i>id</i>. If you want the adjacent nodes to get selected too, provide `true` as the second argument.
 
-<a name="select_node_by_index" href="#select_node_by_index">#</a> graph.<b>selectNodeByIndex</b>(<i>index</i>)
+<a name="select_node_by_index" href="#select_node_by_index">#</a> graph.<b>selectNodeByIndex</b>(<i>index</i>, [<i>selectAdjacentNodes</i>])
 
-Select a node by <i>index</i>.
+Select a node by <i>index</i>. If you want the adjacent nodes to get selected too, provide `true` as the second argument.
 
 <a name="select_node_by_ids" href="#select_node_by_ids">#</a> graph.<b>selectNodesByIds</b>(<i>ids</i>)
 
@@ -165,6 +165,10 @@ Unselect all nodes.
 <a name="get_selected_nodes" href="#get_selected_nodes">#</a> graph.<b>getSelectedNodes</b>()
 
 Get an array of currently selected nodes.
+
+<a name="get_adjacent_nodes_to_node_id" href="#get_adjacent_nodes_to_node_id">#</a> graph.<b>getAdjacentNodes</b>(<i>id</i>)
+
+Get nodes that are adjacent to a specific node by its <i>id</i>.
 
 <a name="start" href="#start">#</a> graph.<b>start</b>([<i>alpha</i>])
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -302,7 +302,7 @@ export class Graph<N extends InputNode, L extends InputLink> {
         })
         .filter(d => d !== -1)
     } else {
-      this.store.selectedIndices = new Float32Array()
+      this.store.selectedIndices = null
     }
     this.points.updateGreyoutStatus()
   }
@@ -327,21 +327,23 @@ export class Graph<N extends InputNode, L extends InputLink> {
    * Select multiples nodes by their ids.
    * @param ids Array of nodes ids.
    */
-  public selectNodesByIds (ids: (string | undefined)[]): void {
-    this.selectNodesByIndices(ids.map(d => this.graph.getSortedIndexById(d)))
+  public selectNodesByIds (ids?: (string | undefined)[] | null): void {
+    this.selectNodesByIndices(ids?.map(d => this.graph.getSortedIndexById(d)))
   }
 
   /**
    * Select multiples nodes by their indices.
    * @param indices Array of nodes indices.
    */
-  public selectNodesByIndices (indices: (number | undefined)[]): void {
-    const filteredIndices = indices.filter(d => d !== undefined) as number[]
-    if (indices.length !== 0) {
-      this.store.selectedIndices = new Float32Array(filteredIndices)
-    } else {
+  public selectNodesByIndices (indices?: (number | undefined)[] | null): void {
+    if (!indices) {
+      this.store.selectedIndices = null
+    } else if (indices.length === 0) {
       this.store.selectedIndices = new Float32Array()
+    } else {
+      this.store.selectedIndices = new Float32Array(indices.filter((d): d is number => d !== undefined))
     }
+
     this.points.updateGreyoutStatus()
   }
 
@@ -349,7 +351,7 @@ export class Graph<N extends InputNode, L extends InputLink> {
    * Unselect all nodes.
    */
   public unselectNodes (): void {
-    this.store.selectedIndices = new Float32Array()
+    this.store.selectedIndices = null
     this.points.updateGreyoutStatus()
   }
 
@@ -357,10 +359,11 @@ export class Graph<N extends InputNode, L extends InputLink> {
    * Get nodes that are currently selected.
    * @returns Array of selected nodes.
    */
-  public getSelectedNodes (): N[] {
-    const points = new Array(this.store.selectedIndices.length)
-    for (let i = 0; i < this.store.selectedIndices.length; i += 1) {
-      const selectedIndex = this.store.selectedIndices[i]
+  public getSelectedNodes (): N[] | null {
+    const { selectedIndices } = this.store
+    if (!selectedIndices) return null
+    const points = new Array(selectedIndices.length)
+    for (const [i, selectedIndex] of selectedIndices.entries()) {
       if (selectedIndex !== undefined) {
         const index = this.graph.getInputIndexBySortedIndex(selectedIndex)
         if (index !== undefined) points[i] = this.graph.nodes[index]

--- a/src/index.ts
+++ b/src/index.ts
@@ -308,19 +308,25 @@ export class Graph<N extends InputNode, L extends InputLink> {
   }
 
   /**
-   * Select a node by id.
+   * Select a node by id. If you want the adjacent nodes to get selected too, provide `true` as the second argument.
    * @param id Id of the node.
+   * @param selectAdjacentNodes When set to `true`, selects adjacent nodes (`false` by default).
    */
-  public selectNodeById (id: string): void {
-    this.selectNodesByIds([id])
+  public selectNodeById (id: string, selectAdjacentNodes = false): void {
+    if (selectAdjacentNodes) {
+      const adjacentNodes = this.graph.getAdjacentNodes(id) ?? []
+      this.selectNodesByIds([id, ...adjacentNodes.map(d => d.id)])
+    } else this.selectNodesByIds([id])
   }
 
   /**
-   * Select a node by index.
+   * Select a node by index. If you want the adjacent nodes to get selected too, provide `true` as the second argument.
    * @param index The index of the node in the array of nodes.
+   * @param selectAdjacentNodes When set to `true`, selects adjacent nodes (`false` by default).
    */
-  public selectNodeByIndex (index: number): void {
-    this.selectNodesByIndices([this.graph.getSortedIndexByInputIndex(index)])
+  public selectNodeByIndex (index: number, selectAdjacentNodes = false): void {
+    const node = this.graph.getNodeByIndex(index)
+    if (node) this.selectNodeById(node.id, selectAdjacentNodes)
   }
 
   /**
@@ -370,6 +376,16 @@ export class Graph<N extends InputNode, L extends InputLink> {
       }
     }
     return points
+  }
+
+  /**
+   * Get nodes that are adjacent to a specific node by its id.
+   * @param id Id of the node.
+   * @returns Array of adjacent nodes.
+   */
+
+  public getAdjacentNodes (id: string): N[] | undefined {
+    return this.graph.getAdjacentNodes(id)
   }
 
   /**

--- a/src/modules/GraphData/index.ts
+++ b/src/modules/GraphData/index.ts
@@ -131,4 +131,13 @@ export class GraphData <N extends InputNode, L extends InputLink> {
   public getSortedIndexById (id: string | undefined): number | undefined {
     return id !== undefined ? this.idToSortedIndexMap.get(id) : undefined
   }
+
+  public getAdjacentNodes (id: string): N[] | undefined {
+    const index = this.getSortedIndexById(id)
+    if (index === undefined) return undefined
+    const outgoingSet = this.groupedSourceToTargetLinks.get(index) ?? []
+    const incomingSet = this.groupedTargetToSourceLinks.get(index) ?? []
+    return [...new Set([...outgoingSet, ...incomingSet])]
+      .map(index => this.getNodeByIndex(this.getInputIndexBySortedIndex(index) as number) as N)
+  }
 }

--- a/src/modules/Points/color-buffer.ts
+++ b/src/modules/Points/color-buffer.ts
@@ -41,15 +41,18 @@ export function createColorBuffer <N extends InputNode, L extends InputLink> (
 }
 
 export function createGreyoutStatusBuffer (
-  selectedIndices: Float32Array,
+  selectedIndices: Float32Array | null,
   reglInstance: regl.Regl,
   textureSize: number
 ): regl.Framebuffer2D {
   // Greyout status: 0 - false, highlighted or normal point; 1 - true, greyout point
-  const initialState = new Float32Array(textureSize * textureSize * 4).fill(selectedIndices.length ? 1 : 0)
+  const initialState = new Float32Array(textureSize * textureSize * 4)
+    .fill(selectedIndices ? 1 : 0)
 
-  for (const selectedIndex of selectedIndices) {
-    initialState[selectedIndex * 4] = 0
+  if (selectedIndices) {
+    for (const selectedIndex of selectedIndices) {
+      initialState[selectedIndex * 4] = 0
+    }
   }
 
   const initialTexture = reglInstance.texture({

--- a/src/modules/Store/index.ts
+++ b/src/modules/Store/index.ts
@@ -15,7 +15,7 @@ export class Store {
   public selectedArea = [[0, 0], [0, 0]]
   public isSimulationRunning = false
   public simulationProgress = 0
-  public selectedIndices: Float32Array = new Float32Array()
+  public selectedIndices: Float32Array | null = null
   public maxPointSize = MAX_POINT_SIZE
   private alphaTarget = 0
   private scaleNodeX = scaleLinear()


### PR DESCRIPTION
Logic tweaks of the API methods `selectNodesByIds` and `selectNodesByIndices`:
- all nodes are greyed out if `ids`/`indices` is an empty array,
- unselect all nodes if `ids`/`indices` are null.

Added second argument to the `selectNodeById` and `selectNodeByIndex` API methods. When set to `true`, selects adjacent nodes. The default is `false`.

Added a new API method `getAdjacentNodes`.