### PR TITLE
Tracking the current position of multiple nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,18 @@ Get node radius by its <i>index</i>.
 
 Get node radius by its <i>id</i>.
 
+<a name="track_nodes_by_ids" href="#track_nodes_by_ids">#</a> graph.<b>trackNodesByIds</b>(<i>ids</i>)
+
+Track multiple node positions by their <i>ids</i>.
+
+<a name="track_nodes_by_indices" href="#track_nodes_by_indices">#</a> graph.<b>trackNodesByIndices</b>(<i>indices</i>)
+
+Track multiple node positions by their <i>indices</i>.
+
+<a name="get_tracked_node_positions_map" href="#get_tracked_node_positions_map">#</a> graph.<b>getTrackedNodePositionsMap</b>()
+
+Get a `Map` object with node coordinates, where keys are the _ids_ of the tracked nodes and the values are their X and Y coordinates in the `[number, number]` format.
+
 <a name="start" href="#start">#</a> graph.<b>start</b>([<i>alpha</i>])
 
 Start the simulation. The <i>alpha</i> value can be from 0 to 1 (1 by default). The higher the value, the more initial energy the simulation will get.

--- a/src/index.ts
+++ b/src/index.ts
@@ -451,6 +451,34 @@ export class Graph<N extends InputNode, L extends InputLink> {
   }
 
   /**
+   * Track multiple node positions by their ids.
+   * @param ids Array of nodes ids.
+   */
+  public trackNodesByIds (ids: string[]): void {
+    this.points.trackNodesByIds(ids)
+  }
+
+  /**
+   * Track multiple node positions by their indices.
+   * @param ids Array of nodes indices.
+   */
+  public trackNodesByIndices (indices: number[]): void {
+    this.points.trackNodesByIds(
+      indices.map(index => this.graph.getNodeByIndex(index))
+        .filter((d): d is N => d !== undefined)
+        .map(d => d.id)
+    )
+  }
+
+  /**
+   * Get current X and Y coordinates of the tracked nodes.
+   * @returns Map where keys are the ids of the nodes and values are corresponding `[number, number]` with X and Y coordinates of the node.
+   */
+  public getTrackedNodePositionsMap (): Map<string, [number, number]> {
+    return this.points.getTrackedPositions()
+  }
+
+  /**
    * Start the simulation.
    * @param alpha Value from 0 to 1. The higher the value, the more initial energy the simulation will get.
    */
@@ -582,6 +610,8 @@ export class Graph<N extends InputNode, L extends InputLink> {
         this.store.simulationProgress = Math.sqrt(Math.min(1, ALPHA_MIN / this.store.alpha))
         this.config.simulation.onTick?.(this.store.alpha)
       }
+
+      this.points.trackPoints()
 
       // Clear canvas
       this.reglInstance.clear({

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,7 @@ export class Graph<N extends InputNode, L extends InputLink> {
 
   /**
    * Get current X and Y coordinates of the nodes.
-   * @returns Map where keys are the ids of the nodes and values are corresponding `[number, number]` with X and Y coordinates of the node.
+   * @returns A Map object where keys are the ids of the nodes and values are their corresponding X and Y coordinates in the [number, number] format.
    */
   public getNodePositionsMap (): Map<string, [number, number]> {
     const positionMap = new Map()
@@ -472,7 +472,7 @@ export class Graph<N extends InputNode, L extends InputLink> {
 
   /**
    * Get current X and Y coordinates of the tracked nodes.
-   * @returns Map where keys are the ids of the nodes and values are corresponding `[number, number]` with X and Y coordinates of the node.
+   * @returns A Map object where keys are the ids of the nodes and values are their corresponding X and Y coordinates in the [number, number] format.
    */
   public getTrackedNodePositionsMap (): Map<string, [number, number]> {
     return this.points.getTrackedPositions()

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -11,9 +11,12 @@ import findHoveredPointVert from '@/graph/modules/Points/find-hovered-point.vert
 import { createSizeBuffer, getNodeSize } from '@/graph/modules/Points/size-buffer'
 import updatePositionFrag from '@/graph/modules/Points/update-position.frag'
 import { createIndexesBuffer, createQuadBuffer } from '@/graph/modules/Shared/buffer'
+import { createTrackedIndicesBuffer, createTrackedPositionsBuffer } from '@/graph/modules/Points/tracked-buffer'
+import trackPositionsFrag from '@/graph/modules/Points/track-positions.frag'
 import updateVert from '@/graph/modules/Shared/quad.vert'
 import clearFrag from '@/graph/modules/Shared/clear.frag'
 import { defaultConfigValues } from '@/graph/variables'
+import { readPixels } from '@/graph/helper'
 import { InputNode, InputLink } from '@/graph/types'
 
 export class Points<N extends InputNode, L extends InputLink> extends CoreModule<N, L> {
@@ -25,12 +28,17 @@ export class Points<N extends InputNode, L extends InputLink> extends CoreModule
   public hoveredFbo: regl.Framebuffer2D | undefined
   public greyoutStatusFbo: regl.Framebuffer2D | undefined
   public sizeFbo: regl.Framebuffer2D | undefined
+  public trackedIndicesFbo: regl.Framebuffer2D | undefined
+  public trackedPositionsFbo: regl.Framebuffer2D | undefined
   private drawCommand: regl.DrawCommand | undefined
   private drawHighlightedCommand: regl.DrawCommand | undefined
   private updatePositionCommand: regl.DrawCommand | undefined
   private findPointsOnAreaSelectionCommand: regl.DrawCommand | undefined
   private findHoveredPointCommand: regl.DrawCommand | undefined
   private clearHoveredFboCommand: regl.DrawCommand | undefined
+  private trackPointsCommand: regl.DrawCommand | undefined
+  private trackedIds: string[] | undefined
+  private trackedPositionsById: Map<string, [number, number]> = new Map()
 
   public create (): void {
     const { reglInstance, config, store, data } = this
@@ -250,6 +258,19 @@ export class Points<N extends InputNode, L extends InputLink> extends CoreModule
         mask: false,
       },
     })
+    this.trackPointsCommand = reglInstance({
+      frag: trackPositionsFrag,
+      vert: updateVert,
+      framebuffer: () => this.trackedPositionsFbo as regl.Framebuffer2D,
+      primitive: 'triangle strip',
+      count: 4,
+      attributes: { quad: createQuadBuffer(reglInstance) },
+      uniforms: {
+        position: () => this.currentPositionFbo,
+        trackedIndices: () => this.trackedIndicesFbo,
+        pointsTextureSize: () => store.pointsTextureSize,
+      },
+    })
   }
 
   public updateColor (): void {
@@ -265,6 +286,11 @@ export class Points<N extends InputNode, L extends InputLink> extends CoreModule
   public updateSize (): void {
     const { reglInstance, config, store, data } = this
     this.sizeFbo = createSizeBuffer(data, reglInstance, store.pointsTextureSize, config.nodeSize)
+  }
+
+  public trackPoints (): void {
+    if (!this.trackedIndicesFbo || !this.trackedPositionsFbo) return
+    this.trackPointsCommand?.()
   }
 
   public draw (): void {
@@ -302,6 +328,36 @@ export class Points<N extends InputNode, L extends InputLink> extends CoreModule
     return getNodeSize(node, nodeSize) / 2
   }
 
+  public trackNodesByIds (ids: string[]): void {
+    this.trackedIds = ids.length ? ids : undefined
+    this.trackedPositionsById.clear()
+    const indices = ids.map(id => this.data.getSortedIndexById(id)).filter((d): d is number => d !== undefined)
+    if (this.trackedIndicesFbo) {
+      this.trackedIndicesFbo.destroy()
+      this.trackedIndicesFbo = undefined
+    }
+    if (this.trackedPositionsFbo) {
+      this.trackedPositionsFbo.destroy()
+      this.trackedPositionsFbo = undefined
+    }
+    if (indices.length) {
+      this.trackedIndicesFbo = createTrackedIndicesBuffer(indices, this.store.pointsTextureSize, this.reglInstance)
+      this.trackedPositionsFbo = createTrackedPositionsBuffer(indices, this.reglInstance)
+    }
+    this.trackPoints()
+  }
+
+  public getTrackedPositions (): Map<string, [number, number]> {
+    if (!this.trackedIds) return this.trackedPositionsById
+    const pixels = readPixels(this.reglInstance, this.trackedPositionsFbo as regl.Framebuffer2D)
+    this.trackedIds.forEach((id, i) => {
+      const x = pixels[i * 4]
+      const y = pixels[i * 4 + 1]
+      if (x !== undefined && y !== undefined) this.trackedPositionsById.set(id, [x, y])
+    })
+    return this.trackedPositionsById
+  }
+
   public destroy (): void {
     this.currentPositionFbo?.destroy()
     this.previousPositionFbo?.destroy()
@@ -311,6 +367,8 @@ export class Points<N extends InputNode, L extends InputLink> extends CoreModule
     this.sizeFbo?.destroy()
     this.greyoutStatusFbo?.destroy()
     this.hoveredFbo?.destroy()
+    this.trackedIndicesFbo?.destroy()
+    this.trackedPositionsFbo?.destroy()
   }
 
   private swapFbo (): void {

--- a/src/modules/Points/track-positions.frag
+++ b/src/modules/Points/track-positions.frag
@@ -1,0 +1,18 @@
+#ifdef GL_ES
+precision highp float;
+#endif
+
+uniform sampler2D position;
+uniform sampler2D trackedIndices;
+uniform float pointsTextureSize;
+
+varying vec2 index;
+
+void main() {
+  vec4 trackedPointIndicies = texture2D(trackedIndices, index);
+  if (trackedPointIndicies.r < 0.0) discard;
+  vec4 pointPosition = texture2D(position, (trackedPointIndicies.rg + 0.5) / pointsTextureSize);
+
+  gl_FragColor = vec4(pointPosition.rg, 1.0, 1.0);
+}
+

--- a/src/modules/Points/tracked-buffer.ts
+++ b/src/modules/Points/tracked-buffer.ts
@@ -1,0 +1,46 @@
+import regl from 'regl'
+
+export function createTrackedPositionsBuffer (
+  indices: number[],
+  reglInstance: regl.Regl
+): regl.Framebuffer2D {
+  const size = Math.ceil(Math.sqrt(indices.length))
+
+  return reglInstance.framebuffer({
+    shape: [size, size],
+    depth: false,
+    stencil: false,
+    colorType: 'float',
+  })
+}
+
+export function createTrackedIndicesBuffer (
+  indices: number[],
+  pointsTextureSize: number,
+  reglInstance: regl.Regl
+): regl.Framebuffer2D {
+  const size = Math.ceil(Math.sqrt(indices.length))
+  const initialState = new Float32Array(size * size * 4).fill(-1)
+
+  for (const [i, sortedIndex] of indices.entries()) {
+    if (sortedIndex !== undefined) {
+      initialState[i * 4] = sortedIndex % pointsTextureSize
+      initialState[i * 4 + 1] = Math.floor(sortedIndex / pointsTextureSize)
+      initialState[i * 4 + 2] = 0
+      initialState[i * 4 + 3] = 0
+    }
+  }
+
+  const initialTexture = reglInstance.texture({
+    data: initialState,
+    width: size,
+    height: size,
+    type: 'float',
+  })
+
+  return reglInstance.framebuffer({
+    color: initialTexture,
+    depth: false,
+    stencil: false,
+  })
+}


### PR DESCRIPTION
New API added:
- `trackNodesByIds`,
- `trackNodesByIndices` and
- `getTrackedNodePositionsMap`.

Allows to track the current coordinates X and Y of multiple nodes by their ids or indices. It is then more efficient to get the coordinates of the tracked nodes.