### PR TITLE
Cleaned up the input nodes and links types

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { D3ZoomEvent } from 'd3-zoom'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 import {
   defaultNodeColor,
   defaultGreyoutNodeOpacity,
@@ -16,7 +16,7 @@ export type StringAccessor<Datum> = ((d: Datum, i?: number, ...rest: unknown[]) 
 export type ColorAccessor<Datum> = ((d: Datum, i?: number, ...rest: unknown[]) => string | [number, number, number, number] | null)
   | string | [number, number, number, number] | null | undefined
 
-export interface GraphEvents <N extends InputNode> {
+export interface GraphEvents <N extends CosmosInputNode> {
   /**
    * Callback function that will be called on every canvas click.
    * If clicked on a node, its data will be passed as the first argument,
@@ -171,8 +171,7 @@ export interface GraphSimulationSettings {
    */
   onRestart?: () => void;
 }
-
-export interface GraphConfigInterface<N extends InputNode, L extends InputLink> {
+export interface GraphConfigInterface<N extends CosmosInputNode, L extends CosmosInputLink> {
   /**
    * Canvas background color.
    * Default value: '#222222'
@@ -307,7 +306,7 @@ export interface GraphConfigInterface<N extends InputNode, L extends InputLink> 
   randomSeed?: number | string;
 }
 
-export class GraphConfig<N extends InputNode, L extends InputLink> implements GraphConfigInterface<N, L> {
+export class GraphConfig<N extends CosmosInputNode, L extends CosmosInputLink> implements GraphConfigInterface<N, L> {
   public backgroundColor = defaultBackgroundColor
   public spaceSize = defaultConfigValues.spaceSize
   public nodeColor = defaultNodeColor

--- a/src/index.ts
+++ b/src/index.ts
@@ -750,5 +750,5 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
   }
 }
 
-export type { CosmosInputLink, CosmosInputNode } from './types'
+export type { CosmosInputNode, CosmosInputLink, InputNode, InputLink } from './types'
 export type { GraphConfigInterface, GraphEvents, GraphSimulationSettings } from './config'

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,10 @@ import { Lines } from '@/graph/modules/Lines'
 import { Points } from '@/graph/modules/Points'
 import { Store, ALPHA_MIN, MAX_POINT_SIZE } from '@/graph/modules/Store'
 import { Zoom } from '@/graph/modules/Zoom'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 import { defaultConfigValues } from '@/graph/variables'
 
-export class Graph<N extends InputNode, L extends InputLink> {
+export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
   public config = new GraphConfig<N, L>()
   private canvas: HTMLCanvasElement
   private canvasD3Selection: Selection<HTMLCanvasElement, undefined, null, undefined>
@@ -750,5 +750,5 @@ export class Graph<N extends InputNode, L extends InputLink> {
   }
 }
 
-export type { InputLink, InputNode } from './types'
+export type { CosmosInputLink, CosmosInputNode } from './types'
 export type { GraphConfigInterface, GraphEvents, GraphSimulationSettings } from './config'

--- a/src/modules/ForceCenter/index.ts
+++ b/src/modules/ForceCenter/index.ts
@@ -6,9 +6,9 @@ import forceFrag from '@/graph/modules/ForceCenter/force-center.frag'
 import { createIndexesBuffer, createQuadBuffer } from '@/graph/modules/Shared/buffer'
 import clearFrag from '@/graph/modules/Shared/clear.frag'
 import updateVert from '@/graph/modules/Shared/quad.vert'
-import { InputLink, InputNode } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
-export class ForceCenter<N extends InputNode, L extends InputLink> extends CoreModule<N, L> {
+export class ForceCenter<N extends CosmosInputNode, L extends CosmosInputLink> extends CoreModule<N, L> {
   private centermassFbo: regl.Framebuffer2D | undefined
   private clearCentermassCommand: regl.DrawCommand | undefined
   private calculateCentermassCommand: regl.DrawCommand | undefined

--- a/src/modules/ForceGravity/index.ts
+++ b/src/modules/ForceGravity/index.ts
@@ -3,9 +3,9 @@ import { CoreModule } from '@/graph/modules/core-module'
 import forceFrag from '@/graph/modules/ForceGravity/force-gravity.frag'
 import { createQuadBuffer } from '@/graph/modules/Shared/buffer'
 import updateVert from '@/graph/modules/Shared/quad.vert'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
-export class ForceGravity<N extends InputNode, L extends InputLink> extends CoreModule<N, L> {
+export class ForceGravity<N extends CosmosInputNode, L extends CosmosInputLink> extends CoreModule<N, L> {
   private runCommand: regl.DrawCommand | undefined
 
   public initPrograms (): void {

--- a/src/modules/ForceLink/index.ts
+++ b/src/modules/ForceLink/index.ts
@@ -3,14 +3,14 @@ import { CoreModule } from '@/graph/modules/core-module'
 import { forceFrag } from '@/graph/modules/ForceLink/force-spring'
 import { createQuadBuffer } from '@/graph/modules/Shared/buffer'
 import updateVert from '@/graph/modules/Shared/quad.vert'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
 export enum LinkDirection {
   OUTGOING = 'outgoing',
   INCOMING = 'incoming'
 }
 
-export class ForceLink<N extends InputNode, L extends InputLink> extends CoreModule<N, L> {
+export class ForceLink<N extends CosmosInputNode, L extends CosmosInputLink> extends CoreModule<N, L> {
   public linkFirstIndicesAndAmountFbo: regl.Framebuffer2D | undefined
   public indicesFbo: regl.Framebuffer2D | undefined
   public biasAndStrengthFbo: regl.Framebuffer2D | undefined

--- a/src/modules/ForceManyBody/index.ts
+++ b/src/modules/ForceManyBody/index.ts
@@ -8,9 +8,9 @@ import { createIndexesBuffer, createQuadBuffer } from '@/graph/modules/Shared/bu
 import clearFrag from '@/graph/modules/Shared/clear.frag'
 import updateVert from '@/graph/modules/Shared/quad.vert'
 import { defaultConfigValues } from '@/graph/variables'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
-export class ForceManyBody<N extends InputNode, L extends InputLink> extends CoreModule<N, L> {
+export class ForceManyBody<N extends CosmosInputNode, L extends CosmosInputLink> extends CoreModule<N, L> {
   private randomValuesFbo: regl.Framebuffer2D | undefined
   private levelsFbos = new Map<string, regl.Framebuffer2D>()
   private clearLevelsCommand: regl.DrawCommand | undefined

--- a/src/modules/ForceManyBodyQuadtree/index.ts
+++ b/src/modules/ForceManyBodyQuadtree/index.ts
@@ -7,9 +7,9 @@ import { createIndexesBuffer, createQuadBuffer } from '@/graph/modules/Shared/bu
 import clearFrag from '@/graph/modules/Shared/clear.frag'
 import updateVert from '@/graph/modules/Shared/quad.vert'
 import { defaultConfigValues } from '@/graph/variables'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
-export class ForceManyBodyQuadtree<N extends InputNode, L extends InputLink> extends CoreModule<N, L> {
+export class ForceManyBodyQuadtree<N extends CosmosInputNode, L extends CosmosInputLink> extends CoreModule<N, L> {
   private randomValuesFbo: regl.Framebuffer2D | undefined
   private levelsFbos = new Map<string, regl.Framebuffer2D>()
   private clearLevelsCommand: regl.DrawCommand | undefined

--- a/src/modules/ForceMouse/index.ts
+++ b/src/modules/ForceMouse/index.ts
@@ -3,9 +3,9 @@ import { CoreModule } from '@/graph/modules/core-module'
 import forceFrag from '@/graph/modules/ForceMouse/force-mouse.frag'
 import { createQuadBuffer } from '@/graph/modules/Shared/buffer'
 import updateVert from '@/graph/modules/Shared/quad.vert'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
-export class ForceMouse<N extends InputNode, L extends InputLink> extends CoreModule<N, L> {
+export class ForceMouse<N extends CosmosInputNode, L extends CosmosInputLink> extends CoreModule<N, L> {
   private runCommand: regl.DrawCommand | undefined
 
   public initPrograms (): void {

--- a/src/modules/GraphData/index.ts
+++ b/src/modules/GraphData/index.ts
@@ -1,6 +1,6 @@
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
-export class GraphData <N extends InputNode, L extends InputLink> {
+export class GraphData <N extends CosmosInputNode, L extends CosmosInputLink> {
   /** Links that have existing source and target nodes  */
   public completeLinks: Set<L> = new Set()
   public degree: number[] = []

--- a/src/modules/Lines/index.ts
+++ b/src/modules/Lines/index.ts
@@ -4,9 +4,9 @@ import { CoreModule } from '@/graph/modules/core-module'
 import drawStraightFrag from '@/graph/modules/Lines/draw-straight.frag'
 import drawStraightVert from '@/graph/modules/Lines/draw-straight.vert'
 import { defaultLinkColor, defaultLinkWidth } from '@/graph/variables'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
-export class Lines<N extends InputNode, L extends InputLink> extends CoreModule<N, L> {
+export class Lines<N extends CosmosInputNode, L extends CosmosInputLink> extends CoreModule<N, L> {
   private drawStraightCommand: regl.DrawCommand | undefined
   private colorBuffer: regl.Buffer | undefined
   private widthBuffer: regl.Buffer | undefined

--- a/src/modules/Points/color-buffer.ts
+++ b/src/modules/Points/color-buffer.ts
@@ -1,11 +1,11 @@
 import regl from 'regl'
 import { ColorAccessor } from '@/graph/config'
 import { getValue, getRgbaColor } from '@/graph/helper'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 import { GraphData } from '@/graph/modules/GraphData'
 import { defaultNodeColor } from '@/graph/variables'
 
-export function createColorBuffer <N extends InputNode, L extends InputLink> (
+export function createColorBuffer <N extends CosmosInputNode, L extends CosmosInputLink> (
   data: GraphData<N, L>,
   reglInstance: regl.Regl,
   textureSize: number,

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -14,9 +14,9 @@ import { createIndexesBuffer, createQuadBuffer } from '@/graph/modules/Shared/bu
 import updateVert from '@/graph/modules/Shared/quad.vert'
 import clearFrag from '@/graph/modules/Shared/clear.frag'
 import { defaultConfigValues } from '@/graph/variables'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
-export class Points<N extends InputNode, L extends InputLink> extends CoreModule<N, L> {
+export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extends CoreModule<N, L> {
   public currentPositionFbo: regl.Framebuffer2D | undefined
   public previousPositionFbo: regl.Framebuffer2D | undefined
   public velocityFbo: regl.Framebuffer2D | undefined

--- a/src/modules/Points/size-buffer.ts
+++ b/src/modules/Points/size-buffer.ts
@@ -2,10 +2,10 @@ import regl from 'regl'
 import { NumericAccessor } from '@/graph/config'
 import { getValue } from '@/graph/helper'
 import { GraphData } from '@/graph/modules/GraphData'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 import { defaultNodeSize } from '@/graph/variables'
 
-export function getNodeSize<N extends InputNode> (
+export function getNodeSize<N extends CosmosInputNode> (
   node: N,
   sizeAccessor: NumericAccessor<N>
 ): number {
@@ -13,7 +13,7 @@ export function getNodeSize<N extends InputNode> (
   return size ?? defaultNodeSize
 }
 
-export function createSizeBuffer <N extends InputNode, L extends InputLink> (
+export function createSizeBuffer <N extends CosmosInputNode, L extends CosmosInputLink> (
   data: GraphData<N, L>,
   reglInstance: regl.Regl,
   pointTextureSize: number,

--- a/src/modules/Zoom/index.ts
+++ b/src/modules/Zoom/index.ts
@@ -3,10 +3,10 @@ import { extent } from 'd3-array'
 import { mat3 } from 'gl-matrix'
 import { Store } from '@/graph/modules/Store'
 import { GraphConfigInterface } from '@/graph/config'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 import { clamp } from '@/graph/helper'
 
-export class Zoom <N extends InputNode, L extends InputLink> {
+export class Zoom <N extends CosmosInputNode, L extends CosmosInputLink> {
   public readonly store: Store<N>
   public readonly config: GraphConfigInterface<N, L>
   public eventTransform = zoomIdentity

--- a/src/modules/core-module.ts
+++ b/src/modules/core-module.ts
@@ -3,9 +3,9 @@ import { GraphConfigInterface } from '@/graph/config'
 import { GraphData } from '@/graph/modules/GraphData'
 import { Points } from '@/graph/modules/Points'
 import { Store } from '@/graph/modules/Store'
-import { InputNode, InputLink } from '@/graph/types'
+import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
-export class CoreModule<N extends InputNode, L extends InputLink> {
+export class CoreModule<N extends CosmosInputNode, L extends CosmosInputLink> {
   public readonly reglInstance: regl.Regl
   public readonly config: GraphConfigInterface<N, L>
   public readonly store: Store<N>

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,3 +8,24 @@ export type CosmosInputLink = {
   source: string;
   target: string;
 }
+
+/**
+ * @deprecated Will be removed from version 2.0. Use type `CosmosInputNode` instead.
+ * @todo Remove deprecated type `InputNode` in version 2.0.
+ */
+export type InputNode = {
+  [key: string]: unknown;
+  id: string;
+  x?: number;
+  y?: number;
+}
+
+/**
+ * @deprecated Will be removed from version 2.0. Use type `CosmosInputLink` instead.
+ * @todo Remove deprecated type `InputLink` in version 2.0.
+ */
+export type InputLink = {
+  [key: string]: unknown;
+  source: string;
+  target: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,10 @@
-export type InputNode = {
-  [key: string]: unknown;
+export type CosmosInputNode = {
   id: string;
   x?: number;
   y?: number;
 }
 
-export type InputLink = {
-  [key: string]: unknown;
+export type CosmosInputLink = {
   source: string;
   target: string;
 }


### PR DESCRIPTION
Cleaned up the input nodes and links types from `[key: string]: unknown;`.
Also renamed `InputNode` to `CosmosInputNode` and `InputLink` to `CosmosInputLink`.