### PR TITLE
Tweaking node highlighting logic

### DIFF
--- a/src/modules/Points/draw-highlighted.frag
+++ b/src/modules/Points/draw-highlighted.frag
@@ -4,13 +4,10 @@ uniform vec4 color;
 uniform float width;
 
 varying vec2 pos;
-varying float isHighlighted;
 
 const float smoothing = 1.05;
 
 void main () {
-  if (isHighlighted == 0.0) discard;
-
   vec2 cxy = pos;
   float r = dot(cxy, cxy);
   float opacity = smoothstep(r, r * smoothing, 1.0);

--- a/src/modules/Points/draw-highlighted.vert
+++ b/src/modules/Points/draw-highlighted.vert
@@ -10,11 +10,10 @@ uniform float sizeScale;
 uniform float spaceSize;
 uniform vec2 screenSize;
 uniform bool scaleNodesOnZoom;
-uniform vec2 hoveredPointIndices;
+uniform float pointIndex;
 uniform float maxPointSize;
 uniform vec4 color;
 
-varying float isHighlighted;
 varying vec2 pos;
 
 float pointSize(float size) {
@@ -30,11 +29,11 @@ float pointSize(float size) {
 const float relativeRingRadius = 1.3;
 
 void main () {
-  if (hoveredPointIndices.r < 0.0) isHighlighted = 0.0;
-  else isHighlighted = 1.0;
   pos = quad;
-  vec4 pointPosition = texture2D(positions, (hoveredPointIndices + 0.5) / pointsTextureSize);
-  vec4 pSize = texture2D(particleSize, (hoveredPointIndices + 0.5) / pointsTextureSize);
+
+  vec2 ij = vec2(mod(pointIndex, pointsTextureSize), floor(pointIndex / pointsTextureSize)) + 0.5;
+  vec4 pointPosition = texture2D(positions, ij / pointsTextureSize);
+  vec4 pSize = texture2D(particleSize, ij / pointsTextureSize);
   float size = (pointSize(pSize.r * sizeScale) * relativeRingRadius) / transform[0][0];
   float radius = size * 0.5;
   vec2 a = pointPosition.xy;

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -229,7 +229,7 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
       uniforms: {
         color: reglInstance.prop<{ color: number[] }, 'color'>('color'),
         width: reglInstance.prop<{ width: number }, 'width'>('width'),
-        hoveredPointIndices: reglInstance.prop<{ pointPosition: number[] }, 'pointPosition'>('pointPosition'),
+        pointIndex: reglInstance.prop<{ pointIndex: number }, 'pointIndex'>('pointIndex'),
         positions: () => this.currentPositionFbo,
         particleSize: () => this.sizeFbo,
         sizeScale: () => config.nodeSizeScale,
@@ -296,16 +296,20 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
   public draw (): void {
     this.drawCommand?.()
     if (this.config.renderHighlightedNodeRing) {
-      this.drawHighlightedCommand?.({
-        width: 0.85,
-        color: this.store.hoveredNodeRingColor,
-        pointPosition: this.store.hoveredNode.indicesFromFbo,
-      })
-      this.drawHighlightedCommand?.({
-        width: 0.75,
-        color: this.store.clickedNodeRingColor,
-        pointPosition: this.store.clickedNode.indicesFromFbo,
-      })
+      if (this.store.hoveredNode) {
+        this.drawHighlightedCommand?.({
+          width: 0.85,
+          color: this.store.hoveredNodeRingColor,
+          pointIndex: this.store.hoveredNode.index,
+        })
+      }
+      if (this.store.focusedNode) {
+        this.drawHighlightedCommand?.({
+          width: 0.75,
+          color: this.store.focusedNodeRingColor,
+          pointIndex: this.store.focusedNode.index,
+        })
+      }
     }
   }
 

--- a/src/modules/Store/index.ts
+++ b/src/modules/Store/index.ts
@@ -2,14 +2,13 @@ import { scaleLinear } from 'd3-scale'
 import { mat3 } from 'gl-matrix'
 import { Random } from 'random'
 import { getRgbaColor } from '@/graph/helper'
-import { hoveredNodeRingOpacity, clickedNodeRingOpacity } from '@/graph/variables'
+import { hoveredNodeRingOpacity, focusedNodeRingOpacity } from '@/graph/variables'
 
 export const ALPHA_MIN = 0.001
 export const MAX_POINT_SIZE = 64
 
-type HighlightedNode<N> = N extends undefined ?
-  { node: undefined; position: undefined; indicesFromFbo: [-1, -1] } :
-  { node: N; position: [ number, number ]; indicesFromFbo: [number, number] }
+type Hovered<Node> = { node: Node; index: number; position: [ number, number ] }
+type Focused<Node> = { node: Node; index: number }
 
 export class Store <N> {
   public pointsTextureSize = 0
@@ -25,20 +24,11 @@ export class Store <N> {
   public simulationProgress = 0
   public selectedIndices: Float32Array | null = null
   public maxPointSize = MAX_POINT_SIZE
-  public hoveredNode: HighlightedNode<N | undefined> = {
-    node: undefined,
-    position: undefined,
-    indicesFromFbo: [-1, -1],
-  }
-
-  public clickedNode: HighlightedNode<N | undefined> = {
-    node: undefined,
-    position: undefined,
-    indicesFromFbo: [-1, -1],
-  }
+  public hoveredNode: Hovered<N> | undefined = undefined
+  public focusedNode: Focused<N> | undefined = undefined
 
   public hoveredNodeRingColor = [1, 1, 1, hoveredNodeRingOpacity]
-  public clickedNodeRingColor = [1, 1, 1, clickedNodeRingOpacity]
+  public focusedNodeRingColor = [1, 1, 1, focusedNodeRingOpacity]
   private alphaTarget = 0
   private scaleNodeX = scaleLinear()
   private scaleNodeY = scaleLinear()
@@ -75,15 +65,15 @@ export class Store <N> {
     this.hoveredNodeRingColor[0] = convertedRgba[0]
     this.hoveredNodeRingColor[1] = convertedRgba[1]
     this.hoveredNodeRingColor[2] = convertedRgba[2]
-    this.clickedNodeRingColor[0] = convertedRgba[0]
-    this.clickedNodeRingColor[1] = convertedRgba[1]
-    this.clickedNodeRingColor[2] = convertedRgba[2]
+    this.focusedNodeRingColor[0] = convertedRgba[0]
+    this.focusedNodeRingColor[1] = convertedRgba[1]
+    this.focusedNodeRingColor[2] = convertedRgba[2]
   }
 
-  public setClickedNode (): void {
-    this.clickedNode.node = this.hoveredNode.node
-    this.clickedNode.position = this.hoveredNode.position
-    this.clickedNode.indicesFromFbo = this.hoveredNode.indicesFromFbo
+  public setFocusedNode (node?: N, index?: number): void {
+    if (node && index !== undefined) {
+      this.focusedNode = { node, index }
+    } else this.focusedNode = undefined
   }
 
   public addAlpha (decay: number): number {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -35,5 +35,5 @@ export const defaultConfigValues = {
 }
 
 export const hoveredNodeRingOpacity = 0.7
-export const clickedNodeRingOpacity = 0.95
+export const focusedNodeRingOpacity = 0.95
 export const defaultScaleToZoom = 3


### PR DESCRIPTION
Highlighted ring for the node will appear when you click on the node or select the node by its id (or index).
On background click as well as on select by nodes ids (or indices) and by the area highlighted ring will disappear.