### PR TITLE
Fixed hovering over a node with a zero index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -751,7 +751,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
     if (nodeSize) {
       const index = pixels[0] as number
       const inputIndex = this.graph.getInputIndexBySortedIndex(index)
-      const hovered = inputIndex ? this.graph.getNodeByIndex(inputIndex) : undefined
+      const hovered = inputIndex !== undefined ? this.graph.getNodeByIndex(inputIndex) : undefined
       if (this.store.hoveredNode?.node !== hovered) isMouseover = true
       const pointX = pixels[2] as number
       const pointY = pixels[3] as number

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -50,10 +50,9 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
       const sortedIndex = this.data.getSortedIndexByInputIndex(i)
       const node = data.nodes[i]
       if (node && sortedIndex !== undefined) {
-        initialState[sortedIndex * 4 + 0] = node.x ??
-          (spaceSize ?? defaultConfigValues.spaceSize) * (store.getRandomFloat(0, 1) * (0.505 - 0.495) + 0.495)
-        initialState[sortedIndex * 4 + 1] = node.y ??
-          (spaceSize ?? defaultConfigValues.spaceSize) * (store.getRandomFloat(0, 1) * (0.505 - 0.495) + 0.495)
+        const space = spaceSize ?? defaultConfigValues.spaceSize
+        initialState[sortedIndex * 4 + 0] = node.x ?? space * store.getRandomFloat(0.495, 0.505)
+        initialState[sortedIndex * 4 + 1] = node.y ?? space * store.getRandomFloat(0.495, 0.505)
       }
     }
 


### PR DESCRIPTION
Hovering over a node with a zero index did not work:

https://user-images.githubusercontent.com/8654114/222089909-5b71b41f-2e4f-4b6e-a15c-27ba3b99bca4.mov


Fixed in this PR. Also added a minor tweak in creating random `X` and `Y` coordinates.

