### PR TITLE
Fixed Regl.js Buffers and Framebuffers double destruction

### DIFF
--- a/src/modules/ForceCenter/index.ts
+++ b/src/modules/ForceCenter/index.ts
@@ -3,7 +3,7 @@ import { CoreModule } from '@/graph/modules/core-module'
 import calculateCentermassFrag from '@/graph/modules/ForceCenter/calculate-centermass.frag'
 import calculateCentermassVert from '@/graph/modules/ForceCenter/calculate-centermass.vert'
 import forceFrag from '@/graph/modules/ForceCenter/force-center.frag'
-import { createIndexesBuffer, createQuadBuffer } from '@/graph/modules/Shared/buffer'
+import { createIndexesBuffer, createQuadBuffer, destroyFramebuffer } from '@/graph/modules/Shared/buffer'
 import clearFrag from '@/graph/modules/Shared/clear.frag'
 import updateVert from '@/graph/modules/Shared/quad.vert'
 import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
@@ -85,6 +85,6 @@ export class ForceCenter<N extends CosmosInputNode, L extends CosmosInputLink> e
   }
 
   public destroy (): void {
-    this.centermassFbo?.destroy()
+    destroyFramebuffer(this.centermassFbo)
   }
 }

--- a/src/modules/ForceLink/index.ts
+++ b/src/modules/ForceLink/index.ts
@@ -1,7 +1,7 @@
 import regl from 'regl'
 import { CoreModule } from '@/graph/modules/core-module'
 import { forceFrag } from '@/graph/modules/ForceLink/force-spring'
-import { createQuadBuffer } from '@/graph/modules/Shared/buffer'
+import { createQuadBuffer, destroyFramebuffer } from '@/graph/modules/Shared/buffer'
 import updateVert from '@/graph/modules/Shared/quad.vert'
 import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
@@ -121,9 +121,9 @@ export class ForceLink<N extends CosmosInputNode, L extends CosmosInputLink> ext
   }
 
   public destroy (): void {
-    this.linkFirstIndicesAndAmountFbo?.destroy()
-    this.indicesFbo?.destroy()
-    this.biasAndStrengthFbo?.destroy()
-    this.randomDistanceFbo?.destroy()
+    destroyFramebuffer(this.linkFirstIndicesAndAmountFbo)
+    destroyFramebuffer(this.indicesFbo)
+    destroyFramebuffer(this.biasAndStrengthFbo)
+    destroyFramebuffer(this.randomDistanceFbo)
   }
 }

--- a/src/modules/ForceManyBody/index.ts
+++ b/src/modules/ForceManyBody/index.ts
@@ -4,7 +4,7 @@ import calculateLevelFrag from '@/graph/modules/ForceManyBody/calculate-level.fr
 import calculateLevelVert from '@/graph/modules/ForceManyBody/calculate-level.vert'
 import forceFrag from '@/graph/modules/ForceManyBody/force-level.frag'
 import forceCenterFrag from '@/graph/modules/ForceManyBody/force-centermass.frag'
-import { createIndexesBuffer, createQuadBuffer } from '@/graph/modules/Shared/buffer'
+import { createIndexesBuffer, createQuadBuffer, destroyFramebuffer } from '@/graph/modules/Shared/buffer'
 import clearFrag from '@/graph/modules/Shared/clear.frag'
 import updateVert from '@/graph/modules/Shared/quad.vert'
 import { defaultConfigValues } from '@/graph/variables'
@@ -193,12 +193,9 @@ export class ForceManyBody<N extends CosmosInputNode, L extends CosmosInputLink>
   }
 
   public destroy (): void {
-    this.randomValuesFbo?.destroy()
+    destroyFramebuffer(this.randomValuesFbo)
     this.levelsFbos.forEach(fbo => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if ((fbo as any)?._framebuffer.framebuffer) {
-        fbo.destroy()
-      }
+      destroyFramebuffer(fbo)
     })
     this.levelsFbos.clear()
   }

--- a/src/modules/ForceManyBodyQuadtree/index.ts
+++ b/src/modules/ForceManyBodyQuadtree/index.ts
@@ -3,7 +3,7 @@ import { CoreModule } from '@/graph/modules/core-module'
 import calculateLevelFrag from '@/graph/modules/ForceManyBody/calculate-level.frag'
 import calculateLevelVert from '@/graph/modules/ForceManyBody/calculate-level.vert'
 import { forceFrag } from '@/graph/modules/ForceManyBody/quadtree-frag-shader'
-import { createIndexesBuffer, createQuadBuffer } from '@/graph/modules/Shared/buffer'
+import { createIndexesBuffer, createQuadBuffer, destroyFramebuffer } from '@/graph/modules/Shared/buffer'
 import clearFrag from '@/graph/modules/Shared/clear.frag'
 import updateVert from '@/graph/modules/Shared/quad.vert'
 import { defaultConfigValues } from '@/graph/variables'
@@ -124,12 +124,9 @@ export class ForceManyBodyQuadtree<N extends CosmosInputNode, L extends CosmosIn
   }
 
   public destroy (): void {
-    this.randomValuesFbo?.destroy()
+    destroyFramebuffer(this.randomValuesFbo)
     this.levelsFbos.forEach(fbo => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if ((fbo as any)?._framebuffer.framebuffer) {
-        fbo.destroy()
-      }
+      destroyFramebuffer(fbo)
     })
     this.levelsFbos.clear()
   }

--- a/src/modules/Lines/index.ts
+++ b/src/modules/Lines/index.ts
@@ -5,6 +5,7 @@ import drawStraightFrag from '@/graph/modules/Lines/draw-straight.frag'
 import drawStraightVert from '@/graph/modules/Lines/draw-straight.vert'
 import { defaultLinkColor, defaultLinkWidth } from '@/graph/variables'
 import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
+import { destroyBuffer } from '@/graph/modules/Shared/buffer'
 
 export class Lines<N extends CosmosInputNode, L extends CosmosInputLink> extends CoreModule<N, L> {
   private drawStraightCommand: regl.DrawCommand | undefined
@@ -148,7 +149,7 @@ export class Lines<N extends CosmosInputNode, L extends CosmosInputLink> extends
   }
 
   public destroy (): void {
-    this.colorBuffer?.destroy()
-    this.widthBuffer?.destroy()
+    destroyBuffer(this.colorBuffer)
+    destroyBuffer(this.widthBuffer)
   }
 }

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -10,7 +10,7 @@ import findHoveredPointFrag from '@/graph/modules/Points/find-hovered-point.frag
 import findHoveredPointVert from '@/graph/modules/Points/find-hovered-point.vert'
 import { createSizeBuffer, getNodeSize } from '@/graph/modules/Points/size-buffer'
 import updatePositionFrag from '@/graph/modules/Points/update-position.frag'
-import { createIndexesBuffer, createQuadBuffer } from '@/graph/modules/Shared/buffer'
+import { createIndexesBuffer, createQuadBuffer, destroyFramebuffer } from '@/graph/modules/Shared/buffer'
 import { createTrackedIndicesBuffer, createTrackedPositionsBuffer } from '@/graph/modules/Points/tracked-buffer'
 import trackPositionsFrag from '@/graph/modules/Points/track-positions.frag'
 import updateVert from '@/graph/modules/Shared/quad.vert'
@@ -335,14 +335,10 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
     this.trackedIds = ids.length ? ids : undefined
     this.trackedPositionsById.clear()
     const indices = ids.map(id => this.data.getSortedIndexById(id)).filter((d): d is number => d !== undefined)
-    if (this.trackedIndicesFbo) {
-      this.trackedIndicesFbo.destroy()
-      this.trackedIndicesFbo = undefined
-    }
-    if (this.trackedPositionsFbo) {
-      this.trackedPositionsFbo.destroy()
-      this.trackedPositionsFbo = undefined
-    }
+    destroyFramebuffer(this.trackedIndicesFbo)
+    this.trackedIndicesFbo = undefined
+    destroyFramebuffer(this.trackedPositionsFbo)
+    this.trackedPositionsFbo = undefined
     if (indices.length) {
       this.trackedIndicesFbo = createTrackedIndicesBuffer(indices, this.store.pointsTextureSize, this.reglInstance)
       this.trackedPositionsFbo = createTrackedPositionsBuffer(indices, this.reglInstance)
@@ -362,16 +358,16 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
   }
 
   public destroy (): void {
-    this.currentPositionFbo?.destroy()
-    this.previousPositionFbo?.destroy()
-    this.velocityFbo?.destroy()
-    this.selectedFbo?.destroy()
-    this.colorFbo?.destroy()
-    this.sizeFbo?.destroy()
-    this.greyoutStatusFbo?.destroy()
-    this.hoveredFbo?.destroy()
-    this.trackedIndicesFbo?.destroy()
-    this.trackedPositionsFbo?.destroy()
+    destroyFramebuffer(this.currentPositionFbo)
+    destroyFramebuffer(this.previousPositionFbo)
+    destroyFramebuffer(this.velocityFbo)
+    destroyFramebuffer(this.selectedFbo)
+    destroyFramebuffer(this.colorFbo)
+    destroyFramebuffer(this.sizeFbo)
+    destroyFramebuffer(this.greyoutStatusFbo)
+    destroyFramebuffer(this.hoveredFbo)
+    destroyFramebuffer(this.trackedIndicesFbo)
+    destroyFramebuffer(this.trackedPositionsFbo)
   }
 
   private swapFbo (): void {

--- a/src/modules/Shared/buffer.ts
+++ b/src/modules/Shared/buffer.ts
@@ -23,3 +23,19 @@ export function createIndexesBuffer (reglInstance: regl.Regl, textureSize: numbe
     size: 2,
   }
 }
+
+export function destroyFramebuffer (fbo?: regl.Framebuffer2D): void {
+  if (!fbo) return
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((fbo as any)?._framebuffer?.framebuffer) {
+    fbo.destroy()
+  }
+}
+
+export function destroyBuffer (fbo?: regl.Buffer): void {
+  if (!fbo) return
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((fbo as any)?._buffer?.buffer) {
+    fbo.destroy()
+  }
+}


### PR DESCRIPTION
Regl.js throws an error if the Buffers or Framebuffers are destroyed twice in a row.
Added method that checks if the Buffers or Framebuffers have already been destroyed.