### PR TITLE
Enhancement for highlighted node ring

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -362,15 +362,15 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
    * Select multiples nodes by their ids.
    * @param ids Array of nodes ids.
    */
-  public selectNodesByIds (ids?: (string | undefined)[] | null): void {
-    this.selectNodesByIndices(ids?.map(d => this.graph.getSortedIndexById(d)))
+  public selectNodesByIds (ids?: (string | undefined)[] | null, focusedNodeId?: string): void {
+    this.selectNodesByIndices(ids?.map(d => this.graph.getSortedIndexById(d)), this.graph.getSortedIndexById(focusedNodeId))
   }
 
   /**
    * Select multiples nodes by their indices.
    * @param indices Array of nodes indices.
    */
-  public selectNodesByIndices (indices?: (number | undefined)[] | null): void {
+  public selectNodesByIndices (indices?: (number | undefined)[] | null, focusedNodeIndex?: number): void {
     if (!indices) {
       this.store.selectedIndices = null
     } else if (indices.length === 0) {
@@ -381,6 +381,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
 
     this.store.setFocusedNode()
     this.points.updateGreyoutStatus()
+    if (focusedNodeIndex !== undefined) this.store.setFocusedNode(this.graph.getNodeByIndex(focusedNodeIndex), focusedNodeIndex)
   }
 
   /**

--- a/src/modules/Points/draw-highlighted.frag
+++ b/src/modules/Points/draw-highlighted.frag
@@ -4,6 +4,7 @@ uniform vec4 color;
 uniform float width;
 
 varying vec2 pos;
+varying float particleOpacity;
 
 const float smoothing = 1.05;
 
@@ -12,5 +13,5 @@ void main () {
   float r = dot(cxy, cxy);
   float opacity = smoothstep(r, r * smoothing, 1.0);
   float stroke = smoothstep(width, width * smoothing, r);
-  gl_FragColor = vec4(color.rgb, opacity * stroke * color.a);
+  gl_FragColor = vec4(color.rgb, opacity * stroke * color.a * particleOpacity);
 }

--- a/src/modules/Points/draw-highlighted.vert
+++ b/src/modules/Points/draw-highlighted.vert
@@ -3,6 +3,8 @@ precision mediump float;
 attribute vec2 quad;
 
 uniform sampler2D positions;
+uniform sampler2D particleColor;
+uniform sampler2D particleGreyoutStatus;
 uniform sampler2D particleSize;
 uniform mat3 transform;
 uniform float pointsTextureSize;
@@ -13,8 +15,10 @@ uniform bool scaleNodesOnZoom;
 uniform float pointIndex;
 uniform float maxPointSize;
 uniform vec4 color;
+uniform float greyoutOpacity;
 
 varying vec2 pos;
+varying float particleOpacity;
 
 float pointSize(float size) {
   float pSize;
@@ -34,6 +38,13 @@ void main () {
   vec2 ij = vec2(mod(pointIndex, pointsTextureSize), floor(pointIndex / pointsTextureSize)) + 0.5;
   vec4 pointPosition = texture2D(positions, ij / pointsTextureSize);
   vec4 pSize = texture2D(particleSize, ij / pointsTextureSize);
+  vec4 pColor = texture2D(particleColor, ij / pointsTextureSize);
+  particleOpacity = pColor.a;
+  // Alpha of selected points
+  vec4 greyoutStatus = texture2D(particleGreyoutStatus, ij / pointsTextureSize);
+  if (greyoutStatus.r > 0.0) {
+    particleOpacity *= greyoutOpacity;
+  }
   float size = (pointSize(pSize.r * sizeScale) * relativeRingRadius) / transform[0][0];
   float radius = size * 0.5;
   vec2 a = pointPosition.xy;

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -230,6 +230,7 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
         width: reglInstance.prop<{ width: number }, 'width'>('width'),
         pointIndex: reglInstance.prop<{ pointIndex: number }, 'pointIndex'>('pointIndex'),
         positions: () => this.currentPositionFbo,
+        particleColor: () => this.colorFbo,
         particleSize: () => this.sizeFbo,
         sizeScale: () => config.nodeSizeScale,
         pointsTextureSize: () => store.pointsTextureSize,
@@ -238,6 +239,8 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
         screenSize: () => store.screenSize,
         scaleNodesOnZoom: () => config.scaleNodesOnZoom,
         maxPointSize: () => store.maxPointSize,
+        particleGreyoutStatus: () => this.greyoutStatusFbo,
+        greyoutOpacity: () => config.nodeGreyoutOpacity,
       },
       blend: {
         enable: true,


### PR DESCRIPTION
This pull request includes the following changes:

1. A second optional argument, `focusedNodeId`, has been added to the `selectNodesByIds` and `selectNodesByIndices` methods. When a node is focused, a ring will be drawn around it as if the node had been clicked.

2. The transparency of the selected node's ring has been adjusted to inherit from the parent node.


