### PR TITLE
Improvements and Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ graph.setData(nodes, links)
 > **Note**
 > If your canvas element has no width and height styles (either CSS or inline) Cosmos will automatically set them to 100%.
 
+> **Warning**
+> If you're going to create a new graph within the same HTML canvas element that already has a graph, **destroy** the previous graph using `graph.destroy()` to prevent unexpected glitches.
+
 Check out the [Wiki](https://github.com/cosmograph-org/cosmos/wiki) for more information on 🛠 [Configuration](https://github.com/cosmograph-org/cosmos/wiki/Cosmos-configuration) and ⚙️ [API Reference](https://github.com/cosmograph-org/cosmos/wiki/API-Reference).
 
 ### Examples

--- a/src/config.ts
+++ b/src/config.ts
@@ -369,6 +369,13 @@ export class GraphConfig<N extends CosmosInputNode, L extends CosmosInputLink> i
 
   public randomSeed = undefined
 
+  public limitSpaceSize (webglMaxTextureSize: number): void {
+    if (this.spaceSize >= webglMaxTextureSize) {
+      this.spaceSize = webglMaxTextureSize / 2
+      console.warn(`The \`spaceSize\` has been reduced to ${this.spaceSize} due to WebGL limits`)
+    }
+  }
+
   public init (config: GraphConfigInterface<N, L>): void {
     (Object.keys(config) as (keyof GraphConfigInterface<N, L>)[])
       .forEach(configParameter => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -211,15 +211,37 @@ export interface GraphConfigInterface<N extends CosmosInputNode, L extends Cosmo
 
   /**
    * Turns the node highlight on hover on / off.
+   * @deprecated Will be removed from version 2.0. Use property `renderHoveredNodeRing` instead.
+   * @todo Remove deprecated type `InputNode` in version 2.0.
    * Default value: `true`
    */
   renderHighlightedNodeRing?: boolean;
 
   /**
+   * Turns ring rendering around a node on hover on / off
+   * Default value: `true`
+   */
+  renderHoveredNodeRing?: boolean;
+
+  /**
    * Highlighted node ring color hex value.
+   * @deprecated Will be removed from version 2.0. Use property `hoveredNodeRingColor` or `focusedNodeRingColor` instead.
+   * @todo Remove deprecated type `InputNode` in version 2.0.
    * Default value: undefined
    */
   highlightedNodeRingColor?: string;
+
+  /**
+   * Hovered node ring color hex value.
+   * Default value: undefined
+   */
+  hoveredNodeRingColor?: string;
+
+  /**
+   * Focused node ring color hex value.
+   * Default value: undefined
+   */
+  focusedNodeRingColor?: string;
 
   /**
    * Turns link rendering on / off.
@@ -321,6 +343,9 @@ export class GraphConfig<N extends CosmosInputNode, L extends CosmosInputLink> i
   public nodeSizeScale = defaultConfigValues.nodeSizeScale
   public renderHighlightedNodeRing = true
   public highlightedNodeRingColor = undefined
+  public renderHoveredNodeRing = true
+  public hoveredNodeRingColor = undefined
+  public focusedNodeRingColor = undefined
   public linkColor = defaultLinkColor
   public linkGreyoutOpacity = defaultGreyoutLinkOpacity
   public linkWidth = defaultLinkWidth

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,7 +336,6 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
     } else {
       this.store.selectedIndices = null
     }
-    this.store.setFocusedNode()
     this.points.updateGreyoutStatus()
   }
 
@@ -350,7 +349,6 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
       const adjacentNodes = this.graph.getAdjacentNodes(id) ?? []
       this.selectNodesByIds([id, ...adjacentNodes.map(d => d.id)])
     } else this.selectNodesByIds([id])
-    this.store.setFocusedNode(this.graph.getNodeById(id), this.graph.getSortedIndexById(id))
   }
 
   /**
@@ -367,15 +365,15 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
    * Select multiples nodes by their ids.
    * @param ids Array of nodes ids.
    */
-  public selectNodesByIds (ids?: (string | undefined)[] | null, focusedNodeId?: string): void {
-    this.selectNodesByIndices(ids?.map(d => this.graph.getSortedIndexById(d)), this.graph.getSortedIndexById(focusedNodeId))
+  public selectNodesByIds (ids?: (string | undefined)[] | null): void {
+    this.selectNodesByIndices(ids?.map(d => this.graph.getSortedIndexById(d)))
   }
 
   /**
    * Select multiples nodes by their indices.
    * @param indices Array of nodes indices.
    */
-  public selectNodesByIndices (indices?: (number | undefined)[] | null, focusedNodeIndex?: number): void {
+  public selectNodesByIndices (indices?: (number | undefined)[] | null): void {
     if (!indices) {
       this.store.selectedIndices = null
     } else if (indices.length === 0) {
@@ -384,9 +382,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
       this.store.selectedIndices = new Float32Array(indices.filter((d): d is number => d !== undefined))
     }
 
-    this.store.setFocusedNode()
     this.points.updateGreyoutStatus()
-    if (focusedNodeIndex !== undefined) this.store.setFocusedNode(this.graph.getNodeByIndex(focusedNodeIndex), focusedNodeIndex)
   }
 
   /**
@@ -394,7 +390,6 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
    */
   public unselectNodes (): void {
     this.store.selectedIndices = null
-    this.store.setFocusedNode()
     this.points.updateGreyoutStatus()
   }
 
@@ -423,6 +418,32 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
 
   public getAdjacentNodes (id: string): N[] | undefined {
     return this.graph.getAdjacentNodes(id)
+  }
+
+  /**
+   * Set focus on a node by id. A ring will be highlighted around the focused node.
+   * If no id is specified, the focus will be reset.
+   * @param id Id of the node.
+   */
+  public setFocusedNodeById (id?: string): void {
+    if (id === undefined) {
+      this.store.setFocusedNode()
+    } else {
+      this.store.setFocusedNode(this.graph.getNodeById(id), this.graph.getSortedIndexById(id))
+    }
+  }
+
+  /**
+   * Set focus on a node by index. A ring will be highlighted around the focused node.
+   * If no index is specified, the focus will be reset.
+   * @param index The index of the node in the array of nodes.
+   */
+  public setFocusedNodeByIndex (index?: number): void {
+    if (index === undefined) {
+      this.store.setFocusedNode()
+    } else {
+      this.store.setFocusedNode(this.graph.getNodeByIndex(index), index)
+    }
   }
 
   /**
@@ -663,7 +684,6 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
   }
 
   private onClick (event: MouseEvent): void {
-    this.store.setFocusedNode(this.store.hoveredNode?.node, this.store.hoveredNode?.index)
     this.config.events.onClick?.(
       this.store.hoveredNode?.node,
       this.store.hoveredNode ? this.graph.getInputIndexBySortedIndex(this.store.hoveredNode.index) : undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
     })
 
     this.store.maxPointSize = (this.reglInstance.limits.pointSizeDims[1] ?? MAX_POINT_SIZE) / this.config.pixelRatio
+    this.config.limitSpaceSize(this.reglInstance.limits.maxTextureSize)
 
     this.points = new Points(this.reglInstance, this.config, this.store, this.graph)
     this.lines = new Lines(this.reglInstance, this.config, this.store, this.graph, this.points)
@@ -145,6 +146,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
     }
     if (prevConfig.spaceSize !== this.config.spaceSize ||
       prevConfig.simulation.repulsionQuadtreeLevels !== this.config.simulation.repulsionQuadtreeLevels) {
+      this.config.limitSpaceSize(this.reglInstance.limits.maxTextureSize)
       this.resizeCanvas(true)
       this.update(this.store.isSimulationRunning)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -583,6 +583,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
   private frame (): void {
     const { config: { simulation, renderLinks }, store: { alpha, isSimulationRunning } } = this
     if (alpha < ALPHA_MIN && isSimulationRunning) this.end()
+    if (!this.store.pointsTextureSize || !this.store.linksTextureSize) return
 
     this.requestAnimationFrameId = window.requestAnimationFrame((now) => {
       this.fpsMonitor?.begin()

--- a/src/index.ts
+++ b/src/index.ts
@@ -604,6 +604,8 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
     this.destroy()
     this.create()
     this.initPrograms()
+    this.setFocusedNodeById()
+    this.store.hoveredNode = undefined
     if (runSimulation) {
       this.start()
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,10 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
       this.store.setHighlightedNodeRingColor(this.config.highlightedNodeRingColor)
     }
     if (prevConfig.spaceSize !== this.config.spaceSize ||
-      prevConfig.simulation.repulsionQuadtreeLevels !== this.config.simulation.repulsionQuadtreeLevels) this.update(this.store.isSimulationRunning)
+      prevConfig.simulation.repulsionQuadtreeLevels !== this.config.simulation.repulsionQuadtreeLevels) {
+      this.resizeCanvas(true)
+      this.update(this.store.isSimulationRunning)
+    }
     if (prevConfig.showFPSMonitor !== this.config.showFPSMonitor) {
       if (this.config.showFPSMonitor) {
         this.fpsMonitor = new FPSMonitor(this.canvas)
@@ -697,13 +700,13 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
     event.preventDefault()
   }
 
-  private resizeCanvas (): void {
+  private resizeCanvas (forceResize = false): void {
     const prevWidth = this.canvas.width
     const prevHeight = this.canvas.height
     const w = this.canvas.clientWidth
     const h = this.canvas.clientHeight
 
-    if (prevWidth !== w * this.config.pixelRatio || prevHeight !== h * this.config.pixelRatio) {
+    if (forceResize || prevWidth !== w * this.config.pixelRatio || prevHeight !== h * this.config.pixelRatio) {
       this.store.updateScreenSize(w, h, this.config.spaceSize)
       this.canvas.width = w * this.config.pixelRatio
       this.canvas.height = h * this.config.pixelRatio
@@ -714,6 +717,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
   }
 
   private setZoomTransformByNodePositions (positions: [number, number][], duration = 250, scale?: number): void {
+    this.resizeCanvas()
     const transform = this.zoomInstance.getTransform(positions, scale)
     this.canvasD3Selection
       .transition()

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,16 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
     this.forceMouse = new ForceMouse(this.reglInstance, this.config, this.store, this.graph, this.points)
 
     this.store.backgroundColor = getRgbaColor(this.config.backgroundColor)
-    if (this.config.highlightedNodeRingColor) this.store.setHighlightedNodeRingColor(this.config.highlightedNodeRingColor)
+    if (this.config.highlightedNodeRingColor) {
+      this.store.setHoveredNodeRingColor(this.config.highlightedNodeRingColor)
+      this.store.setFocusedNodeRingColor(this.config.highlightedNodeRingColor)
+    }
+    if (this.config.hoveredNodeRingColor) {
+      this.store.setHoveredNodeRingColor(this.config.hoveredNodeRingColor)
+    }
+    if (this.config.focusedNodeRingColor) {
+      this.store.setFocusedNodeRingColor(this.config.focusedNodeRingColor)
+    }
 
     if (this.config.showFPSMonitor) this.fpsMonitor = new FPSMonitor(this.canvas)
 
@@ -142,7 +151,14 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
     if (prevConfig.linkWidth !== this.config.linkWidth) this.lines.updateWidth()
     if (prevConfig.backgroundColor !== this.config.backgroundColor) this.store.backgroundColor = getRgbaColor(this.config.backgroundColor)
     if (prevConfig.highlightedNodeRingColor !== this.config.highlightedNodeRingColor) {
-      this.store.setHighlightedNodeRingColor(this.config.highlightedNodeRingColor)
+      this.store.setHoveredNodeRingColor(this.config.highlightedNodeRingColor)
+      this.store.setFocusedNodeRingColor(this.config.highlightedNodeRingColor)
+    }
+    if (prevConfig.hoveredNodeRingColor !== this.config.hoveredNodeRingColor) {
+      this.store.setHoveredNodeRingColor(this.config.hoveredNodeRingColor)
+    }
+    if (prevConfig.focusedNodeRingColor !== this.config.focusedNodeRingColor) {
+      this.store.setFocusedNodeRingColor(this.config.focusedNodeRingColor)
     }
     if (prevConfig.spaceSize !== this.config.spaceSize ||
       prevConfig.simulation.repulsionQuadtreeLevels !== this.config.simulation.repulsionQuadtreeLevels) {

--- a/src/modules/ForceLink/index.ts
+++ b/src/modules/ForceLink/index.ts
@@ -22,6 +22,7 @@ export class ForceLink<N extends CosmosInputNode, L extends CosmosInputLink> ext
 
   public create (direction: LinkDirection): void {
     const { reglInstance, store: { pointsTextureSize, linksTextureSize }, data } = this
+    if (!pointsTextureSize || !linksTextureSize) return
     this.linkFirstIndicesAndAmount = new Float32Array(pointsTextureSize * pointsTextureSize * 4)
     this.indices = new Float32Array(linksTextureSize * linksTextureSize * 4)
     const linkBiasAndStrengthState = new Float32Array(linksTextureSize * linksTextureSize * 4)

--- a/src/modules/ForceManyBody/index.ts
+++ b/src/modules/ForceManyBody/index.ts
@@ -22,6 +22,7 @@ export class ForceManyBody<N extends CosmosInputNode, L extends CosmosInputLink>
 
   public create (): void {
     const { reglInstance, config, store } = this
+    if (!store.pointsTextureSize) return
     this.quadtreeLevels = Math.log2(config.spaceSize ?? defaultConfigValues.spaceSize)
     for (let i = 0; i < this.quadtreeLevels; i += 1) {
       const levelTextureSize = Math.pow(2, i + 1)

--- a/src/modules/ForceManyBodyQuadtree/index.ts
+++ b/src/modules/ForceManyBodyQuadtree/index.ts
@@ -19,6 +19,7 @@ export class ForceManyBodyQuadtree<N extends CosmosInputNode, L extends CosmosIn
 
   public create (): void {
     const { reglInstance, config, store } = this
+    if (!store.pointsTextureSize) return
     this.quadtreeLevels = Math.log2(config.spaceSize ?? defaultConfigValues.spaceSize)
     for (let i = 0; i < this.quadtreeLevels; i += 1) {
       const levelTextureSize = Math.pow(2, i + 1)

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -299,22 +299,21 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
   }
 
   public draw (): void {
+    const { config: { renderHoveredNodeRing, renderHighlightedNodeRing }, store } = this
     this.drawCommand?.()
-    if (this.config.renderHighlightedNodeRing) {
-      if (this.store.hoveredNode) {
-        this.drawHighlightedCommand?.({
-          width: 0.85,
-          color: this.store.hoveredNodeRingColor,
-          pointIndex: this.store.hoveredNode.index,
-        })
-      }
-      if (this.store.focusedNode) {
-        this.drawHighlightedCommand?.({
-          width: 0.75,
-          color: this.store.focusedNodeRingColor,
-          pointIndex: this.store.focusedNode.index,
-        })
-      }
+    if ((renderHoveredNodeRing ?? renderHighlightedNodeRing) && store.hoveredNode) {
+      this.drawHighlightedCommand?.({
+        width: 0.85,
+        color: store.hoveredNodeRingColor,
+        pointIndex: store.hoveredNode.index,
+      })
+    }
+    if (store.focusedNode) {
+      this.drawHighlightedCommand?.({
+        width: 0.75,
+        color: store.focusedNodeRingColor,
+        pointIndex: store.focusedNode.index,
+      })
     }
   }
 

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -44,6 +44,7 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
     const { reglInstance, config, store, data } = this
     const { spaceSize } = config
     const { pointsTextureSize } = store
+    if (!pointsTextureSize) return
     const numParticles = data.nodes.length
     const initialState = new Float32Array(pointsTextureSize * pointsTextureSize * 4)
     for (let i = 0; i < numParticles; ++i) {
@@ -276,8 +277,9 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
   }
 
   public updateColor (): void {
-    const { reglInstance, config, store, data } = this
-    this.colorFbo = createColorBuffer(data, reglInstance, store.pointsTextureSize, config.nodeColor)
+    const { reglInstance, config, store: { pointsTextureSize }, data } = this
+    if (!pointsTextureSize) return
+    this.colorFbo = createColorBuffer(data, reglInstance, pointsTextureSize, config.nodeColor)
   }
 
   public updateGreyoutStatus (): void {
@@ -286,8 +288,9 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
   }
 
   public updateSize (): void {
-    const { reglInstance, config, store, data } = this
-    this.sizeFbo = createSizeBuffer(data, reglInstance, store.pointsTextureSize, config.nodeSize)
+    const { reglInstance, config, store: { pointsTextureSize }, data } = this
+    if (!pointsTextureSize) return
+    this.sizeFbo = createSizeBuffer(data, reglInstance, pointsTextureSize, config.nodeSize)
   }
 
   public trackPoints (): void {

--- a/src/modules/Store/index.ts
+++ b/src/modules/Store/index.ts
@@ -60,11 +60,15 @@ export class Store <N> {
     return this.scaleNodeY(y)
   }
 
-  public setHighlightedNodeRingColor (color: string): void {
+  public setHoveredNodeRingColor (color: string): void {
     const convertedRgba = getRgbaColor(color)
     this.hoveredNodeRingColor[0] = convertedRgba[0]
     this.hoveredNodeRingColor[1] = convertedRgba[1]
     this.hoveredNodeRingColor[2] = convertedRgba[2]
+  }
+
+  public setFocusedNodeRingColor (color: string): void {
+    const convertedRgba = getRgbaColor(color)
     this.focusedNodeRingColor[0] = convertedRgba[0]
     this.focusedNodeRingColor[1] = convertedRgba[1]
     this.focusedNodeRingColor[2] = convertedRgba[2]


### PR DESCRIPTION
1. Prevents Cosmos from crashing if there are no nodes or links. (Patch)
2. Updates space and screen size when `spaceSize` configuration parameter is changed or before the zoom in/out transformation occurs, and fixes the `fitView` when called before animation starts. (Patch)
3. Prevents Cosmos from crashing when the `spaceSize` configuration parameter exceeds the WebGL limit. (Patch)
4. Resetting the focused and hovered node after `graph.setData()`. (Patch)
5. New methods (`setFocusedNodeById` and `setFocusedNodeByIndex`) and config parameters (`renderHoveredNodeRing`, `hoveredNodeRingColor` and `focusedNodeRingColor`). (Minor)


