### PR TITLE
Make `graph` field public for advanced use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,13 +22,13 @@ import { defaultConfigValues, defaultScaleToZoom } from '@/graph/variables'
 
 export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
   public config = new GraphConfig<N, L>()
+  public graph = new GraphData<N, L>()
   private canvas: HTMLCanvasElement
   private canvasD3Selection: Selection<HTMLCanvasElement, undefined, null, undefined>
   private reglInstance: regl.Regl
   private requestAnimationFrameId = 0
   private isRightClickMouse = false
 
-  private graph = new GraphData<N, L>()
   private store = new Store<N>()
   private points: Points<N, L>
   private lines: Lines<N, L>


### PR DESCRIPTION
This change makes the `graph` field public in the main `Graph` class. The `graph` itself is a class where data processing happens. By making the `graph` field public, users can access its properties and methods directly, which may be useful in certain cases.