### PR TITLE
New config property - `initialZoomLevel`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -324,6 +324,11 @@ export interface GraphConfigInterface<N extends CosmosInputNode, L extends Cosmo
    */
   scaleNodesOnZoom?: boolean;
   /**
+   * Initial zoom level. Can be set once during graph initialization.
+   * Default value: `1`
+   */
+  initialZoomLevel?: number;
+  /**
    * Providing a `randomSeed` value allows you to control
    * the randomness of the layout across different simulation runs.
    * It is useful when you want the graph to always look the same on same datasets.
@@ -391,6 +396,7 @@ export class GraphConfig<N extends CosmosInputNode, L extends CosmosInputLink> i
   public pixelRatio = defaultConfigValues.pixelRatio
 
   public scaleNodesOnZoom = defaultConfigValues.scaleNodesOnZoom
+  public initialZoomLevel = defaultConfigValues.initialZoomLevel
 
   public randomSeed = undefined
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
       .on('click', this.onClick.bind(this))
       .on('mousemove', this.onMouseMove.bind(this))
       .on('contextmenu', this.onRightClickMouse.bind(this))
+    this.setZoomLevel(this.config.initialZoomLevel)
 
     this.reglInstance = regl({
       canvas: this.canvas,

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -32,6 +32,7 @@ export const defaultConfigValues = {
   showFPSMonitor: false,
   pixelRatio: 2,
   scaleNodesOnZoom: true,
+  initialZoomLevel: 1,
 }
 
 export const hoveredNodeRingOpacity = 0.7


### PR DESCRIPTION
The initial zoom level can be set once during graph initialization.