### PR TITLE
Keep the `spaceSize` configuration parameter stable

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -406,13 +406,6 @@ export class GraphConfig<N extends CosmosInputNode, L extends CosmosInputLink> i
 
   public randomSeed = undefined
 
-  public limitSpaceSize (webglMaxTextureSize: number): void {
-    if (this.spaceSize >= webglMaxTextureSize) {
-      this.spaceSize = webglMaxTextureSize / 2
-      console.warn(`The \`spaceSize\` has been reduced to ${this.spaceSize} due to WebGL limits`)
-    }
-  }
-
   public init (config: GraphConfigInterface<N, L>): void {
     (Object.keys(config) as (keyof GraphConfigInterface<N, L>)[])
       .forEach(configParameter => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,6 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
 
     const w = canvas.clientWidth
     const h = canvas.clientHeight
-    this.store.updateScreenSize(w, h, this.config.spaceSize)
 
     canvas.width = w * this.config.pixelRatio
     canvas.height = h * this.config.pixelRatio
@@ -103,7 +102,8 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
     })
 
     this.store.maxPointSize = (this.reglInstance.limits.pointSizeDims[1] ?? MAX_POINT_SIZE) / this.config.pixelRatio
-    this.config.limitSpaceSize(this.reglInstance.limits.maxTextureSize)
+    this.store.adjustSpaceSize(this.config.spaceSize, this.reglInstance.limits.maxTextureSize)
+    this.store.updateScreenSize(w, h)
 
     this.points = new Points(this.reglInstance, this.config, this.store, this.graph)
     this.lines = new Lines(this.reglInstance, this.config, this.store, this.graph, this.points)
@@ -177,7 +177,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
     }
     if (prevConfig.spaceSize !== this.config.spaceSize ||
       prevConfig.simulation.repulsionQuadtreeLevels !== this.config.simulation.repulsionQuadtreeLevels) {
-      this.config.limitSpaceSize(this.reglInstance.limits.maxTextureSize)
+      this.store.adjustSpaceSize(this.config.spaceSize, this.reglInstance.limits.maxTextureSize)
       this.resizeCanvas(true)
       this.update(this.store.isSimulationRunning)
     }
@@ -741,8 +741,8 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
     const invertedX = (mouseX - x) / k
     const invertedY = (mouseY - y) / k
     this.store.mousePosition = [invertedX, (h - invertedY)]
-    this.store.mousePosition[0] -= (this.store.screenSize[0] - this.config.spaceSize) / 2
-    this.store.mousePosition[1] -= (this.store.screenSize[1] - this.config.spaceSize) / 2
+    this.store.mousePosition[0] -= (this.store.screenSize[0] - this.store.adjustedSpaceSize) / 2
+    this.store.mousePosition[1] -= (this.store.screenSize[1] - this.store.adjustedSpaceSize) / 2
     this.store.screenMousePosition = [mouseX, (this.store.screenSize[1] - mouseY)]
   }
 
@@ -769,7 +769,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
     const h = this.canvas.clientHeight
 
     if (forceResize || prevWidth !== w * this.config.pixelRatio || prevHeight !== h * this.config.pixelRatio) {
-      this.store.updateScreenSize(w, h, this.config.spaceSize)
+      this.store.updateScreenSize(w, h)
       this.canvas.width = w * this.config.pixelRatio
       this.canvas.height = h * this.config.pixelRatio
       this.reglInstance.poll()

--- a/src/modules/ForceGravity/index.ts
+++ b/src/modules/ForceGravity/index.ts
@@ -20,7 +20,7 @@ export class ForceGravity<N extends CosmosInputNode, L extends CosmosInputLink> 
       uniforms: {
         position: () => points?.previousPositionFbo,
         gravity: () => config.simulation?.gravity,
-        spaceSize: () => config.spaceSize,
+        spaceSize: () => store.adjustedSpaceSize,
         alpha: () => store.alpha,
       },
     })

--- a/src/modules/ForceManyBody/index.ts
+++ b/src/modules/ForceManyBody/index.ts
@@ -7,7 +7,6 @@ import forceCenterFrag from '@/graph/modules/ForceManyBody/force-centermass.frag
 import { createIndexesBuffer, createQuadBuffer, destroyFramebuffer } from '@/graph/modules/Shared/buffer'
 import clearFrag from '@/graph/modules/Shared/clear.frag'
 import updateVert from '@/graph/modules/Shared/quad.vert'
-import { defaultConfigValues } from '@/graph/variables'
 import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
 export class ForceManyBody<N extends CosmosInputNode, L extends CosmosInputLink> extends CoreModule<N, L> {
@@ -21,9 +20,9 @@ export class ForceManyBody<N extends CosmosInputNode, L extends CosmosInputLink>
   private quadtreeLevels = 0
 
   public create (): void {
-    const { reglInstance, config, store } = this
+    const { reglInstance, store } = this
     if (!store.pointsTextureSize) return
-    this.quadtreeLevels = Math.log2(config.spaceSize ?? defaultConfigValues.spaceSize)
+    this.quadtreeLevels = Math.log2(store.adjustedSpaceSize)
     for (let i = 0; i < this.quadtreeLevels; i += 1) {
       const levelTextureSize = Math.pow(2, i + 1)
       this.levelsFbos.set(`level[${i}]`, reglInstance.framebuffer({
@@ -105,7 +104,7 @@ export class ForceManyBody<N extends CosmosInputNode, L extends CosmosInputLink>
         levelTextureSize: (_, props) => props.levelTextureSize,
         alpha: () => store.alpha,
         repulsion: () => config.simulation?.repulsion,
-        spaceSize: () => config.spaceSize,
+        spaceSize: () => store.adjustedSpaceSize,
         theta: () => config.simulation?.repulsionTheta,
       },
       blend: {
@@ -136,7 +135,7 @@ export class ForceManyBody<N extends CosmosInputNode, L extends CosmosInputLink>
         levelTextureSize: (_, props) => props.levelTextureSize,
         alpha: () => store.alpha,
         repulsion: () => config.simulation?.repulsion,
-        spaceSize: () => config.spaceSize,
+        spaceSize: () => store.adjustedSpaceSize,
       },
       blend: {
         enable: true,
@@ -163,11 +162,11 @@ export class ForceManyBody<N extends CosmosInputNode, L extends CosmosInputLink>
   }
 
   public run (): void {
-    const { config } = this
+    const { store } = this
     for (let i = 0; i < this.quadtreeLevels; i += 1) {
       this.clearLevelsCommand?.({ levelFbo: this.levelsFbos.get(`level[${i}]`) })
       const levelTextureSize = Math.pow(2, i + 1)
-      const cellSize = (config.spaceSize ?? defaultConfigValues.spaceSize) / levelTextureSize
+      const cellSize = store.adjustedSpaceSize / levelTextureSize
       this.calculateLevelsCommand?.({
         levelFbo: this.levelsFbos.get(`level[${i}]`),
         levelTextureSize,

--- a/src/modules/Lines/index.ts
+++ b/src/modules/Lines/index.ts
@@ -88,7 +88,7 @@ export class Lines<N extends CosmosInputNode, L extends CosmosInputLink> extends
         widthScale: () => config.linkWidthScale,
         useArrow: () => config.linkArrows,
         arrowSizeScale: () => config.linkArrowsSizeScale,
-        spaceSize: () => config.spaceSize,
+        spaceSize: () => store.adjustedSpaceSize,
         screenSize: () => store.screenSize,
         ratio: () => config.pixelRatio,
         linkVisibilityDistanceRange: () => config.linkVisibilityDistanceRange,

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -15,7 +15,6 @@ import { createTrackedIndicesBuffer, createTrackedPositionsBuffer } from '@/grap
 import trackPositionsFrag from '@/graph/modules/Points/track-positions.frag'
 import updateVert from '@/graph/modules/Shared/quad.vert'
 import clearFrag from '@/graph/modules/Shared/clear.frag'
-import { defaultConfigValues } from '@/graph/variables'
 import { readPixels } from '@/graph/helper'
 import { CosmosInputNode, CosmosInputLink } from '@/graph/types'
 
@@ -41,9 +40,8 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
   private trackedPositionsById: Map<string, [number, number]> = new Map()
 
   public create (): void {
-    const { reglInstance, config, store, data } = this
-    const { spaceSize } = config
-    const { pointsTextureSize } = store
+    const { reglInstance, store, data } = this
+    const { pointsTextureSize, adjustedSpaceSize } = store
     if (!pointsTextureSize) return
     const numParticles = data.nodes.length
     const initialState = new Float32Array(pointsTextureSize * pointsTextureSize * 4)
@@ -51,9 +49,8 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
       const sortedIndex = this.data.getSortedIndexByInputIndex(i)
       const node = data.nodes[i]
       if (node && sortedIndex !== undefined) {
-        const space = spaceSize ?? defaultConfigValues.spaceSize
-        initialState[sortedIndex * 4 + 0] = node.x ?? space * store.getRandomFloat(0.495, 0.505)
-        initialState[sortedIndex * 4 + 1] = node.y ?? space * store.getRandomFloat(0.495, 0.505)
+        initialState[sortedIndex * 4 + 0] = node.x ?? adjustedSpaceSize * store.getRandomFloat(0.495, 0.505)
+        initialState[sortedIndex * 4 + 1] = node.y ?? adjustedSpaceSize * store.getRandomFloat(0.495, 0.505)
       }
     }
 
@@ -125,7 +122,7 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
         position: () => this.previousPositionFbo,
         velocity: () => this.velocityFbo,
         friction: () => config.simulation?.friction,
-        spaceSize: () => config.spaceSize,
+        spaceSize: () => store.adjustedSpaceSize,
       },
     })
     this.drawCommand = reglInstance({
@@ -143,7 +140,7 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
         sizeScale: () => config.nodeSizeScale,
         pointsTextureSize: () => store.pointsTextureSize,
         transform: () => store.transform,
-        spaceSize: () => config.spaceSize,
+        spaceSize: () => store.adjustedSpaceSize,
         screenSize: () => store.screenSize,
         greyoutOpacity: () => config.nodeGreyoutOpacity,
         scaleNodesOnZoom: () => config.scaleNodesOnZoom,
@@ -176,7 +173,7 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
       uniforms: {
         position: () => this.currentPositionFbo,
         particleSize: () => this.sizeFbo,
-        spaceSize: () => config.spaceSize,
+        spaceSize: () => store.adjustedSpaceSize,
         screenSize: () => store.screenSize,
         sizeScale: () => config.nodeSizeScale,
         transform: () => store.transform,
@@ -209,7 +206,7 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
         sizeScale: () => config.nodeSizeScale,
         pointsTextureSize: () => store.pointsTextureSize,
         transform: () => store.transform,
-        spaceSize: () => config.spaceSize,
+        spaceSize: () => store.adjustedSpaceSize,
         screenSize: () => store.screenSize,
         scaleNodesOnZoom: () => config.scaleNodesOnZoom,
         mousePosition: () => store.screenMousePosition,
@@ -236,7 +233,7 @@ export class Points<N extends CosmosInputNode, L extends CosmosInputLink> extend
         sizeScale: () => config.nodeSizeScale,
         pointsTextureSize: () => store.pointsTextureSize,
         transform: () => store.transform,
-        spaceSize: () => config.spaceSize,
+        spaceSize: () => store.adjustedSpaceSize,
         screenSize: () => store.screenSize,
         scaleNodesOnZoom: () => config.scaleNodesOnZoom,
         maxPointSize: () => store.maxPointSize,


### PR DESCRIPTION
If the `spaceSize` configuration value was outside the WebGL limits, it resulted in unnecessary graph updates on the next config update.