### PR TITLE
Storing the node size in a Float32Array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -513,8 +513,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
    * @returns Radius of the node.
    */
   public getNodeRadiusByIndex (index: number): number | undefined {
-    const node = this.graph.getNodeByIndex(index)
-    return node && this.points.getNodeRadius(node, index)
+    return this.points.getNodeRadiusByIndex(index)
   }
 
   /**
@@ -523,8 +522,9 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
    * @returns Radius of the node.
    */
   public getNodeRadiusById (id: string): number | undefined {
-    const node = this.graph.getNodeById(id)
-    return node && this.points.getNodeRadius(node, this.graph.getInputIndexById(id))
+    const index = this.graph.getInputIndexById(id)
+    if (index === undefined) return undefined
+    return this.points.getNodeRadiusByIndex(index)
   }
 
   /**

--- a/src/modules/Points/size-buffer.ts
+++ b/src/modules/Points/size-buffer.ts
@@ -14,11 +14,12 @@ export function getNodeSize<N extends CosmosInputNode> (
   return size ?? defaultNodeSize
 }
 
-export function createSizeBuffer <N extends CosmosInputNode, L extends CosmosInputLink> (
+export function createSizeBufferAndFillSizeStore <N extends CosmosInputNode, L extends CosmosInputLink> (
   data: GraphData<N, L>,
   reglInstance: regl.Regl,
   pointTextureSize: number,
-  sizeAccessor: NumericAccessor<N>
+  sizeAccessor: NumericAccessor<N>,
+  sizeStore: Float32Array
 ): regl.Framebuffer2D | undefined {
   if (pointTextureSize === 0) return undefined
   const numParticles = data.nodes.length
@@ -28,7 +29,9 @@ export function createSizeBuffer <N extends CosmosInputNode, L extends CosmosInp
     const sortedIndex = data.getSortedIndexByInputIndex(i)
     const node = data.nodes[i]
     if (node && sortedIndex !== undefined) {
-      initialState[sortedIndex * 4] = getNodeSize(node, sizeAccessor, i)
+      const nodeSize = getNodeSize(node, sizeAccessor, i)
+      initialState[sortedIndex * 4] = nodeSize
+      sizeStore[i] = nodeSize
     }
   }
 


### PR DESCRIPTION
This is done to efficiently store and access the node sizes without the need to recalculate them every time they are needed.