### PR TITLE
Bump ttypescript from 1.5.13 to 1.5.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "rollup": "^2.76.0",
         "rollup-plugin-glslify": "^1.3.0",
         "rollup-plugin-typescript2": "^0.32.1",
-        "ttypescript": "^1.5.13",
+        "ttypescript": "^1.5.15",
         "typescript": "^4.7.4"
       },
       "engines": {
@@ -5368,9 +5368,9 @@
       "dev": true
     },
     "node_modules/ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "dependencies": {
         "resolve": ">=1.9.0"
@@ -9518,9 +9518,9 @@
       }
     },
     "ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "requires": {
         "resolve": ">=1.9.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rollup": "^2.76.0",
     "rollup-plugin-glslify": "^1.3.0",
     "rollup-plugin-typescript2": "^0.32.1",
-    "ttypescript": "^1.5.13",
+    "ttypescript": "^1.5.15",
     "typescript": "^4.7.4"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request fixes an error occurring when building the library with node js version 20 and ttypescript version 1.5.13. The error was:

<img width="820" alt="Screenshot 2024-02-29 at 11 14 16" src="https://github.com/cosmograph-org/cosmos/assets/8654114/e6f85987-8925-4761-97f5-365b27620c7d">


Upgrading ttypescript to version 1.5.15 resolved the issue.