### PR TITLE
Update initial zoom behavior

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -356,7 +356,7 @@ export interface GraphConfigInterface<N extends CosmosInputNode, L extends Cosmo
   scaleNodesOnZoom?: boolean;
   /**
    * Initial zoom level. Can be set once during graph initialization.
-   * Default value: `1`
+   * Default value: `undefined`
    */
   initialZoomLevel?: number;
   /**
@@ -460,7 +460,7 @@ export class GraphConfig<N extends CosmosInputNode, L extends CosmosInputLink> i
   public pixelRatio = defaultConfigValues.pixelRatio
 
   public scaleNodesOnZoom = defaultConfigValues.scaleNodesOnZoom
-  public initialZoomLevel = defaultConfigValues.initialZoomLevel
+  public initialZoomLevel = undefined
   public disableZoom = defaultConfigValues.disableZoom
   public fitViewOnInit = defaultConfigValues.fitViewOnInit
   public fitViewDelay = defaultConfigValues.fitViewDelay

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
       .on('mousemove', this.onMouseMove.bind(this))
       .on('contextmenu', this.onRightClickMouse.bind(this))
     if (this.config.disableZoom) this.disableZoom()
-    this.setZoomLevel(this.config.initialZoomLevel)
+    this.setZoomLevel(this.config.initialZoomLevel ?? 1)
 
     this.reglInstance = regl({
       canvas: this.canvas,
@@ -218,7 +218,7 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
    * @param runSimulation When set to `false`, the simulation won't be started automatically (`true` by default).
    */
   public setData (nodes: N[], links: L[], runSimulation = true): void {
-    const { fitViewOnInit, fitViewDelay, fitViewByNodesInRect } = this.config
+    const { fitViewOnInit, fitViewDelay, fitViewByNodesInRect, initialZoomLevel } = this.config
     if (!nodes.length && !links.length) {
       this.destroyParticleSystem()
       this.reglInstance.clear({
@@ -229,7 +229,8 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
       return
     }
     this.graph.setData(nodes, links)
-    if (this._isFirstDataAfterInit && fitViewOnInit) {
+    // If `initialZoomLevel` is set, we don't need to fit the view
+    if (this._isFirstDataAfterInit && fitViewOnInit && initialZoomLevel === undefined) {
       this._fitViewOnInitTimeoutID = window.setTimeout(() => {
         if (fitViewByNodesInRect) this.setZoomTransformByNodePositions(fitViewByNodesInRect, undefined, undefined, 0)
         else this.fitView()

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -39,7 +39,6 @@ export const defaultConfigValues = {
   showFPSMonitor: false,
   pixelRatio: 2,
   scaleNodesOnZoom: true,
-  initialZoomLevel: 1,
   disableZoom: false,
   fitViewOnInit: true,
   fitViewDelay: 250,


### PR DESCRIPTION


* The `initialZoomLevel` configuration parameter is now `undefined` by default.
* If `initialZoomLevel` is set, the view will not be fit to the initial zoom level.