### PR TITLE
Add support for background color with transparency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,8 +100,6 @@ export class Graph<N extends CosmosInputNode, L extends CosmosInputLink> {
       attributes: {
         antialias: false,
         preserveDrawingBuffer: true,
-        premultipliedAlpha: false,
-        alpha: false,
       },
       extensions: ['OES_texture_float', 'ANGLE_instanced_arrays'],
     })


### PR DESCRIPTION
The configuration property `backgroundColor` now supports color with transparency in the format `rgba(r, g, b, a)`, where `a` is the opacity value. For example, `rgba(0, 0, 0, 0)` would set the background color to black with no opacity.

🙏 This change was inspired by an issue raised by [miklevin](https://github.com/miklevin) in the cosmograph-issues repository (https://github.com/cosmograph-org/cosmograph-issues/issues/14).