### PR TITLE
Add pinned points functionality

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -593,6 +593,29 @@ export class Graph {
   }
 
   /**
+   * Sets which points are pinned (fixed) in position.
+   *
+   * Pinned points:
+   * - Do not move due to physics forces (gravity, repulsion, link forces, etc.)
+   * - Still participate in force calculations (other nodes are attracted to/repelled by them)
+   * - Can still be dragged by the user if `enableDrag` is true
+   *
+   * @param {number[] | null} pinnedIndices - Array of point indices to pin. Set to `[]` or `null` to unpin all points.
+   * @example
+   *   // Pin points 0 and 5
+   *   graph.setPinnedPoints([0, 5])
+   *
+   *   // Unpin all points
+   *   graph.setPinnedPoints([])
+   *   graph.setPinnedPoints(null)
+   */
+  public setPinnedPoints (pinnedIndices: number[] | null): void {
+    if (this._isDestroyed || !this.points) return
+    this.graph.inputPinnedPoints = pinnedIndices && pinnedIndices.length > 0 ? pinnedIndices : undefined
+    this.points.updatePinnedStatus()
+  }
+
+  /**
    * Renders the graph.
    *
    * @param {number} [simulationAlpha] - Optional value between 0 and 1

--- a/src/modules/GraphData/index.ts
+++ b/src/modules/GraphData/index.ts
@@ -27,6 +27,7 @@ export class GraphData {
   public inputPointClusters: (number | undefined)[] | undefined
   public inputClusterPositions: (number | undefined)[] | undefined
   public inputClusterStrength: Float32Array | undefined
+  public inputPinnedPoints: number[] | undefined
 
   public pointPositions: Float32Array | undefined
   public pointColors: Float32Array | undefined

--- a/src/modules/Points/update-position.frag
+++ b/src/modules/Points/update-position.frag
@@ -4,6 +4,7 @@ precision highp float;
 
 uniform sampler2D positionsTexture;
 uniform sampler2D velocity;
+uniform sampler2D pinnedStatusTexture;
 uniform float friction;
 uniform float spaceSize;
 
@@ -12,6 +13,17 @@ varying vec2 textureCoords;
 void main() {
   vec4 pointPosition = texture2D(positionsTexture, textureCoords);
   vec4 pointVelocity = texture2D(velocity, textureCoords);
+
+  // Check if point is pinned
+  // pinnedStatusTexture has the same size and layout as positionsTexture
+  // Each pixel corresponds to a point: red channel > 0.5 means the point is pinned
+  vec4 pinnedStatus = texture2D(pinnedStatusTexture, textureCoords);
+  
+  // If pinned, don't update position
+  if (pinnedStatus.r > 0.5) {
+    gl_FragColor = pointPosition;
+    return;
+  }
 
   // Friction
   pointVelocity.rg *= friction;

--- a/src/stories/beginners.stories.ts
+++ b/src/stories/beginners.stories.ts
@@ -7,6 +7,7 @@ import { basicSetUp } from './beginners/basic-set-up'
 import { pointLabels } from './beginners/point-labels'
 import { removePoints } from './beginners/remove-points'
 import { linkHovering } from './beginners/link-hovering'
+import { pinnedPoints } from './beginners/pinned-points'
 
 import quickStartStoryRaw from './beginners/quick-start?raw'
 import basicSetUpStoryRaw from './beginners/basic-set-up/index?raw'
@@ -23,6 +24,8 @@ import removePointsStoryDataGenRaw from './beginners/remove-points/data-gen.ts?r
 import linkHoveringStoryRaw from './beginners/link-hovering/index?raw'
 import linkHoveringStoryDataGenRaw from './beginners/link-hovering/data-generator.ts?raw'
 import linkHoveringStoryCssRaw from './beginners/link-hovering/style.css?raw'
+import pinnedPointsStoryRaw from './beginners/pinned-points/index?raw'
+import pinnedPointsStoryDataGenRaw from './beginners/pinned-points/data-gen.ts?raw'
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta: Meta<CosmosStoryProps> = {
@@ -109,6 +112,17 @@ export const LinkHovering: Story = {
       { name: 'Story', code: linkHoveringStoryRaw },
       { name: 'data-generator.ts', code: linkHoveringStoryDataGenRaw },
       { name: 'style.css', code: linkHoveringStoryCssRaw },
+    ],
+  },
+}
+
+export const PinnedPoints: Story = {
+  ...createStory(pinnedPoints),
+  name: 'Pinned Points',
+  parameters: {
+    sourceCode: [
+      { name: 'Story', code: pinnedPointsStoryRaw },
+      { name: 'data-gen.ts', code: pinnedPointsStoryDataGenRaw },
     ],
   },
 }

--- a/src/stories/beginners/pinned-points/data-gen.ts
+++ b/src/stories/beginners/pinned-points/data-gen.ts
@@ -1,0 +1,153 @@
+// Note: This is vibe coding only - quick prototype code for demonstration purposes
+
+function getRandom (min: number, max: number): number {
+  return Math.random() * (max - min) + min
+}
+
+function hslToRgb (hue: number, saturation: number, lightness: number): [number, number, number] {
+  const c = (1 - Math.abs(2 * lightness - 1)) * saturation
+  const x = c * (1 - Math.abs(((hue / 60) % 2) - 1))
+  const m = lightness - c / 2
+
+  let r, g, b
+  if (hue >= 0 && hue < 60) {
+    r = c; g = x; b = 0
+  } else if (hue >= 60 && hue < 120) {
+    r = x; g = c; b = 0
+  } else if (hue >= 120 && hue < 180) {
+    r = 0; g = c; b = x
+  } else if (hue >= 180 && hue < 240) {
+    r = 0; g = x; b = c
+  } else if (hue >= 240 && hue < 300) {
+    r = x; g = 0; b = c
+  } else {
+    r = c; g = 0; b = x
+  }
+
+  return [r + m, g + m, b + m]
+}
+
+export function generateData (numNodes = 60): { pointPositions: Float32Array; links: Float32Array; pointColors: Float32Array } {
+  const pointPositions = new Float32Array(numNodes * 2)
+  const pointColors = new Float32Array(numNodes * 4)
+  const linksArray: number[] = []
+
+  const centerX = 2048
+  const centerY = 2048
+  const circleRadius = 900
+
+  // First, place 6 nodes in a perfect circle with equal spacing
+  const numCircleNodes = 6
+  for (let i = 0; i < numCircleNodes; i++) {
+    const angle = (i / numCircleNodes) * Math.PI * 2
+    const x = centerX + Math.cos(angle) * circleRadius
+    const y = centerY + Math.sin(angle) * circleRadius
+
+    pointPositions[i * 2] = x
+    pointPositions[i * 2 + 1] = y
+
+    // Color based on position - rainbow gradient
+    const hue = (i / numNodes) * 360
+    const [r, g, b] = hslToRgb(hue, 0.7, 0.6)
+
+    pointColors[i * 4] = r
+    pointColors[i * 4 + 1] = g
+    pointColors[i * 4 + 2] = b
+    pointColors[i * 4 + 3] = 1.0
+  }
+
+  // Create remaining nodes in clusters around the space
+  const numClusters = 4
+  const remainingNodes = numNodes - numCircleNodes
+  const nodesPerCluster = Math.floor(remainingNodes / numClusters)
+
+  for (let cluster = 0; cluster < numClusters; cluster++) {
+    const clusterAngle = (cluster / numClusters) * Math.PI * 2
+    const clusterRadius = 1200
+    const clusterX = centerX + Math.cos(clusterAngle) * clusterRadius
+    const clusterY = centerY + Math.sin(clusterAngle) * clusterRadius
+
+    const startIndex = numCircleNodes + cluster * nodesPerCluster
+    const endIndex = cluster === numClusters - 1 ? numNodes : startIndex + nodesPerCluster
+
+    for (let i = startIndex; i < endIndex; i++) {
+      // Position nodes in a small cluster
+      const angle = (i - startIndex) / (endIndex - startIndex) * Math.PI * 2
+      const radius = 300 + getRandom(-50, 50)
+      const x = clusterX + Math.cos(angle) * radius * getRandom(0.7, 1.3)
+      const y = clusterY + Math.sin(angle) * radius * getRandom(0.7, 1.3)
+
+      pointPositions[i * 2] = x
+      pointPositions[i * 2 + 1] = y
+
+      // Color based on position - rainbow gradient
+      const hue = (i / numNodes) * 360
+      const [r, g, b] = hslToRgb(hue, 0.7, 0.6)
+
+      pointColors[i * 4] = r
+      pointColors[i * 4 + 1] = g
+      pointColors[i * 4 + 2] = b
+      pointColors[i * 4 + 3] = 1.0
+    }
+  }
+
+  // Create links: connect the 6 circle nodes to form a ring
+  for (let i = 0; i < numCircleNodes; i++) {
+    const nextIndex = (i + 1) % numCircleNodes
+    linksArray.push(i)
+    linksArray.push(nextIndex)
+  }
+
+  // Connect circle nodes to nearby cluster nodes - more connections
+  for (let i = 0; i < numCircleNodes; i++) {
+    const circleAngle = (i / numCircleNodes) * Math.PI * 2
+    // Find nearest cluster and connect to many nodes in it
+    const nearestCluster = Math.floor((circleAngle / (Math.PI * 2)) * numClusters) % numClusters
+    const clusterStart = numCircleNodes + nearestCluster * nodesPerCluster
+    const clusterEnd = nearestCluster === numClusters - 1 ? numNodes : clusterStart + nodesPerCluster
+    // Connect to many nodes in the nearest cluster
+    for (let j = clusterStart; j < Math.min(clusterStart + Math.floor(nodesPerCluster * 0.6), clusterEnd); j++) {
+      linksArray.push(i)
+      linksArray.push(j)
+    }
+    // Also connect to some nodes in adjacent clusters
+    const nextCluster = (nearestCluster + 1) % numClusters
+    const nextClusterStart = numCircleNodes + nextCluster * nodesPerCluster
+    const nextClusterEnd = nextCluster === numClusters - 1 ? numNodes : nextClusterStart + nodesPerCluster
+    for (let j = nextClusterStart; j < Math.min(nextClusterStart + Math.floor(nodesPerCluster * 0.3), nextClusterEnd); j++) {
+      linksArray.push(i)
+      linksArray.push(j)
+    }
+  }
+
+  // Connect nodes within clusters and some cross-cluster links
+  for (let i = numCircleNodes; i < numNodes; i++) {
+    const cluster = Math.floor((i - numCircleNodes) / nodesPerCluster)
+    const clusterStart = numCircleNodes + cluster * nodesPerCluster
+    const clusterEnd = cluster === numClusters - 1 ? numNodes : clusterStart + nodesPerCluster
+
+    // Connect to nearby nodes in the same cluster
+    for (let j = clusterStart; j < clusterEnd; j++) {
+      if (i !== j && Math.abs(i - j) <= 3) {
+        linksArray.push(i)
+        linksArray.push(j)
+      }
+    }
+
+    // Connect to nodes in adjacent clusters (sparse connections)
+    if (i % 3 === 0) {
+      const nextCluster = (cluster + 1) % numClusters
+      const nextClusterStart = numCircleNodes + nextCluster * nodesPerCluster
+      const nextClusterEnd = nextCluster === numClusters - 1 ? numNodes : nextClusterStart + nodesPerCluster
+      const targetIndex = nextClusterStart + Math.floor(((i - clusterStart) % nodesPerCluster) * (nextClusterEnd - nextClusterStart) / nodesPerCluster)
+      if (targetIndex < numNodes && targetIndex >= numCircleNodes) {
+        linksArray.push(i)
+        linksArray.push(targetIndex)
+      }
+    }
+  }
+
+  const links = new Float32Array(linksArray)
+
+  return { pointPositions, links, pointColors }
+}

--- a/src/stories/beginners/pinned-points/index.ts
+++ b/src/stories/beginners/pinned-points/index.ts
@@ -1,0 +1,61 @@
+import { Graph } from '@cosmos.gl/graph'
+import { generateData } from './data-gen'
+
+export const pinnedPoints = (): { graph: Graph; div: HTMLDivElement} => {
+  const div = document.createElement('div')
+  div.style.height = '100vh'
+  div.style.width = '100%'
+  div.style.position = 'relative'
+
+  const infoPanel = document.createElement('div')
+  infoPanel.textContent = 'White points are pinned. Try to move them.'
+  Object.assign(infoPanel.style, {
+    position: 'absolute',
+    top: '20px',
+    left: '20px',
+    color: 'white',
+    fontSize: '14px',
+  })
+  div.appendChild(infoPanel)
+
+  const graph = new Graph(div, {
+    spaceSize: 4096,
+    backgroundColor: '#2d313a',
+    curvedLinks: true,
+    enableDrag: true,
+    simulationLinkSpring: 3.1,
+    simulationRepulsion: 150,
+    simulationGravity: 0.05,
+    simulationDecay: 10000000,
+    attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmosgl-attribution-color);" target="_blank">Cosmograph</a>',
+  })
+
+  const { pointPositions, links, pointColors } = generateData(100)
+
+  const pinnedIndices = [0, 1, 2, 3, 4, 5]
+  const numPoints = pointPositions.length / 2
+
+  const colors = new Float32Array(pointColors)
+  for (const pinnedIndex of pinnedIndices) {
+    colors[pinnedIndex * 4] = 1.0
+    colors[pinnedIndex * 4 + 1] = 1.0
+    colors[pinnedIndex * 4 + 2] = 1.0
+    colors[pinnedIndex * 4 + 3] = 1.0
+  }
+
+  const pointSizes = new Float32Array(numPoints).fill(12)
+  for (const pinnedIndex of pinnedIndices) {
+    pointSizes[pinnedIndex] = 30
+  }
+
+  graph.setPointPositions(pointPositions)
+  graph.setPointColors(colors)
+  graph.setPointSizes(pointSizes)
+  graph.setLinks(links)
+  graph.setPinnedPoints(pinnedIndices)
+
+  graph.zoom(0.8)
+  graph.render()
+
+  return { div, graph }
+}


### PR DESCRIPTION
Allows pinning specific graph points so they ignore physics forces but can still apply forces to other nodes.

https://github.com/user-attachments/assets/1cb4e9fd-535b-4171-8ec6-c112bc5283ef

- Added `setPinnedPoints(pinnedIndices: number[] | null)` method
- Pinned points do not move due to physics forces (gravity, repulsion, link forces)
- Pinned points still participate in force calculations (other nodes are affected by their forces)
- Pinned points can still be dragged by the user if `enableDrag` is enabled
- Setting `pinnedIndices` to `[]` or `null` unpins all points

**Example:**
```typescript
// Pin points 0 and 5
graph.setPinnedPoints([0, 5])

// Unpin all points
graph.setPinnedPoints(null)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Points can now be pinned to maintain their positions during physics simulation while remaining draggable and participating in forces with other points.
  * Introduced new `setPinnedPoints()` API method enabling flexible control over which points are pinned or unpinned via point indices.
  * Added a new "Pinned Points" interactive example demonstrating the pinning feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->