### PR TITLE
Fix: Update image sizes buffer when adding points dynamically

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -340,6 +340,7 @@ export class Graph {
     this.isPointSizeUpdateNeeded = true
     this.isPointShapeUpdateNeeded = true
     this.isPointImageIndicesUpdateNeeded = true
+    this.isPointImageSizesUpdateNeeded = true
     this.isPointClusterUpdateNeeded = true
     this.isForceManyBodyUpdateNeeded = true
     this.isForceLinkUpdateNeeded = true
@@ -1361,6 +1362,8 @@ export class Graph {
         // To prevent the dragged point from suddenly jumping, run the drag function twice
         this.points?.drag()
         this.points?.drag()
+        // Update tracked positions after drag, even when simulation is disabled
+        this.points?.trackPoints()
       }
       this.fpsMonitor?.end(now)
 


### PR DESCRIPTION
When dynamically adding points via `setPointPositions()`, the image sizes buffer wasn't being updated, causing WebGL errors: "Vertex buffer is not big enough for the draw call."

## Solution
Added `isPointImageSizesUpdateNeeded = true` flag in `setPointPositions()` to ensure image sizes buffer updates when point count changes.

## Additional Changes
- Added `trackPoints()` call after drag operations for consistency (separate improvement, not related to the main problem)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Point image sizes now correctly update when point positions change.
  * Drag operations now properly track position changes even when the simulation is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->