### PR TITLE
Release 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cosmos.gl/graph",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cosmos.gl/graph",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmos.gl/graph",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "GPU-based force graph layout and rendering",
   "jsdelivr": "dist/index.min.js",
   "main": "dist/index.js",


### PR DESCRIPTION
This PR prepares the release of version 2.6.0.

### Changes

#### Features
- **Pinned Points Functionality** ([#179](https://github.com/cosmosgl/graph/pull/179))
  - Added `setPinnedPoints()` method to pin/unpin specific points
  - Pinned points are fixed in position but still participate in force calculations
  - Pinned points can still be dragged if `enableDrag` is enabled
  - Added new story example demonstrating pinned points functionality

#### API Changes
- **Rename `pointColor` to `pointDefaultColor`** ([#182](https://github.com/cosmosgl/graph/pull/182))
  - Deprecated `pointColor` configuration option in favor of `pointDefaultColor`
  - `pointColor` still works but will be removed in a future version
  - Updated documentation to reflect the new naming

#### Bug Fixes
- **Image sizes buffer and tracked positions** ([#181](https://github.com/cosmosgl/graph/pull/181))
  - Fixed image sizes buffer not updating when adding points dynamically
  - Fixed tracked positions not updating after drag operations when simulation is disabled

#### Documentation & Infrastructure
- **Security escalation policy** ([#176](https://github.com/cosmosgl/graph/pull/176))
  - Added escalation section to security policy with clear rules for reporting security issues
  
- **Storybook improvements** ([#180](https://github.com/cosmosgl/graph/pull/180))
  - Added link to GitHub repository in Storybook

#### Dependencies
- Bumped vite dependency ([#174](https://github.com/cosmosgl/graph/pull/174))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.6.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->