### PR TITLE
Rename `linkColor` to `linkDefaultColor`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -147,6 +147,9 @@ export interface GraphConfigInterface {
    * in the format `[red, green, blue, alpha]` where each value is a number between 0 and 255.
    * Default value: '#666666'
    */
+  linkDefaultColor?: string | [number, number, number, number];
+
+  /** @deprecated Use `linkDefaultColor` instead */
   linkColor?: string | [number, number, number, number];
 
   /**
@@ -635,6 +638,11 @@ export class GraphConfig implements GraphConfigInterface {
   public focusedPointRingColor = defaultConfigValues.focusedPointRingColor
   public focusedPointIndex = defaultConfigValues.focusedPointIndex
   public linkColor = defaultLinkColor
+  // TODO: When linkColor is removed, change this to:
+  // public linkDefaultColor = defaultLinkColor
+  // Currently undefined to allow fallback to deprecated linkColor via nullish coalescing
+  // in GraphData.updateLinkColor() (see: this._config.linkDefaultColor ?? this._config.linkColor)
+  public linkDefaultColor = undefined
   public linkOpacity = defaultLinkOpacity
   public linkGreyoutOpacity = defaultGreyoutLinkOpacity
   public linkWidth = defaultLinkWidth

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,7 +256,8 @@ export class Graph {
       this.graph.updatePointSize()
       this.points.updateSize()
     }
-    if (prevConfig.linkColor !== this.config.linkColor) {
+    if ((prevConfig.linkDefaultColor !== this.config.linkDefaultColor) ||
+      (prevConfig.linkColor !== this.config.linkColor)) {
       this.graph.updateLinkColor()
       this.lines.updateColor()
     }

--- a/src/modules/GraphData/index.ts
+++ b/src/modules/GraphData/index.ts
@@ -222,7 +222,7 @@ export class GraphData {
     }
 
     // Sets link colors to default values from config if the input is missing or does not match input links number.
-    const defaultRgba = getRgbaColor(this._config.linkColor)
+    const defaultRgba = getRgbaColor(this._config.linkDefaultColor ?? this._config.linkColor)
     if (this.inputLinkColors === undefined || this.inputLinkColors.length / 4 !== this.linksNumber) {
       this.linkColors = new Float32Array(this.linksNumber * 4)
 

--- a/src/stories/2. configuration.mdx
+++ b/src/stories/2. configuration.mdx
@@ -23,7 +23,8 @@ import { Meta } from "@storybook/blocks";
 | focusedPointRingColor | Focused point ring color hex value or an array of RGBA values | `white` |
 | focusedPointIndex | Set focus on a point by index. A ring will be highlighted around the focused point. When set to `undefined`, no point is focused. | `undefined` |
 | renderLinks | Turns link rendering on / off | `true` |
-| linkColor | The default color to use for links when no link colors are provided, or if the color value in the array is `undefined` or `null`. This can be either a hex color string (e.g., '#666666') or an array of RGBA values in the format `[red, green, blue, alpha]` where each value is a number between 0 and 255 | `#666666` |
+| linkDefaultColor | The default color to use for links when no link colors are provided, or if the color value in the array is `undefined` or `null`. This can be either a hex color string (e.g., '#666666') or an array of RGBA values in the format `[red, green, blue, alpha]` where each value is a number between 0 and 255 | `#666666` |
+| linkColor | **[DEPRECATED]** Use `linkDefaultColor` instead. The default color to use for links when no link colors are provided... | `#666666` |
 | linkOpacity | Universal opacity value applied to all links. This value multiplies with individual link alpha values (if set via setLinkColors). Useful for dynamically controlling opacity of all links without updating individual RGBA arrays. | `1.0` |
 | linkGreyoutOpacity | Greyed out link opacity value when the selection is active | `0.1` |
 | linkWidth | The default width value to use for links when no link widths are provided or if the width value in the array is `undefined` or `null` | `1` |

--- a/src/stories/beginners/basic-set-up/index.ts
+++ b/src/stories/beginners/basic-set-up/index.ts
@@ -26,7 +26,7 @@ export const basicSetUp = (): { graph: Graph; div: HTMLDivElement} => {
     pointDefaultColor: '#4B5BBF',
     linkWidth: 0.6,
     scalePointsOnZoom: true,
-    linkColor: '#5F74C2',
+    linkDefaultColor: '#5F74C2',
     linkArrows: false,
     linkGreyoutOpacity: 0,
     curvedLinks: true,

--- a/src/stories/beginners/point-labels/index.ts
+++ b/src/stories/beginners/point-labels/index.ts
@@ -32,7 +32,7 @@ export const pointLabels = (
     backgroundColor: '#2d313a',
     scalePointsOnZoom: true,
     linkWidth: 0.6,
-    linkColor: '#5F74C2',
+    linkDefaultColor: '#5F74C2',
     linkArrows: false,
     fitViewOnInit: false,
     enableDrag: true,

--- a/src/stories/beginners/remove-points/config.ts
+++ b/src/stories/beginners/remove-points/config.ts
@@ -8,7 +8,7 @@ export const config: GraphConfigInterface = {
   scalePointsOnZoom: true,
   pointGreyoutOpacity: 0.1,
   linkWidth: 0.6,
-  linkColor: '#5F74C2',
+  linkDefaultColor: '#5F74C2',
   linkArrows: false,
   linkGreyoutOpacity: 0,
   hoveredPointCursor: 'pointer',

--- a/src/stories/create-cosmos.ts
+++ b/src/stories/create-cosmos.ts
@@ -27,7 +27,7 @@ export const createCosmos = (props: CosmosStoryProps): { div: HTMLDivElement; gr
     pointGreyoutOpacity: 0.1,
     scalePointsOnZoom: true,
     linkWidth: 0.8,
-    linkColor: '#5F74C2',
+    linkDefaultColor: '#5F74C2',
     linkArrows: false,
     linkGreyoutOpacity: 0,
     curvedLinks: true,


### PR DESCRIPTION
Like in https://github.com/cosmosgl/graph/pull/182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `linkDefaultColor` configuration property for customizing default link appearance.

* **Documentation**
  * Updated configuration guide and examples. The `linkColor` property is now marked as deprecated in favor of `linkDefaultColor`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->