### PR TITLE
Add stories tsconfig and wire ESLint to it

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": "./tsconfig.json"
+    "project": ["./tsconfig.json", "./src/stories/tsconfig.json"]
   },
   "rules": {
     "object-curly-spacing": ["error", "always"],

--- a/src/stories/tsconfig.json
+++ b/src/stories/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../..",
+    "paths": {
+      "@cosmos.gl/graph": ["src/"],
+      "@cosmos.gl/graph/*": ["src/*"],
+      "@/graph": ["src/"],
+      "@/graph/*": ["src/*"]
+    },
+    "declaration": false,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": []
+}


### PR DESCRIPTION
## Problem
Stories were excluded from the main `tsconfig.json` to avoid generating unwanted declaration files during publish, but that meant TypeScript and ESLint lacked proper project context for `src/stories`, reducing IDE support during development.

## Solution
- Added `src/stories/tsconfig.json` extending the root config, with path aliases to `src/` and emit disabled.
- Updated `.eslintrc` `parserOptions.project` to include the new stories config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint TypeScript parser configuration to enhance type-checking coverage across the project.
  * Added TypeScript configuration file for story files to improve consistency in the development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->