### PR TITLE
Center rescaled node positions in simulation space

### DIFF
--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -2193,10 +2193,11 @@ export class Points extends CoreModule {
 
     // Calculate uniform scale factor to fit data within effective space
     const scaleFactor = effectiveSpaceSize / range
-    // Center the data horizontally by adding padding on x-axis
-    const offsetX = ((range - w) / 2) * scaleFactor
-    // Center the data vertically by adding padding on y-axis
-    const offsetY = ((range - h) / 2) * scaleFactor
+    // Shift to center the scaled data within the full [0, spaceSize] space
+    const centerOffset = (spaceSize - effectiveSpaceSize) / 2
+    // Pad the shorter axis so both axes are centered within the square bounding box
+    const offsetX = ((range - w) / 2) * scaleFactor + centerOffset
+    const offsetY = ((range - h) / 2) * scaleFactor + centerOffset
 
     this.scaleX = (x: number): number => (x - minX) * scaleFactor + offsetX
     this.scaleY = (y: number): number => (y - minY) * scaleFactor + offsetY


### PR DESCRIPTION
Rescaled node positions are now centered in the simulation space `[0, spaceSize]` instead of being anchored at the bottom-left corner.

Before:

https://github.com/user-attachments/assets/5a7ab36d-0a4c-4191-9f89-5cf2e433ae0a


After:

https://github.com/user-attachments/assets/542ac3ba-f3a6-4df4-909d-b9b6d581da2d


Fixes [#192](https://github.com/cosmosgl/graph/issues/192) — *Rescaled points are placed in the bottom-left corner instead of the center of the simulation space.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved point positioning and centering calculations in data visualizations to ensure points are accurately mapped within their designated space bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->