### PR TITLE
Fix hover detection order to match draw order with selection

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -458,16 +458,17 @@ export interface GraphConfigInterface {
   /**
    * Callback function that will be called when a point appears under the mouse
    * as a result of a mouse event, zooming and panning, or movement of points.
-   * The point index will be passed as the first argument, position as the second argument
-   * and the corresponding mouse event or D3's zoom event as the third argument:
-   * `(index: number, pointPosition: [number, number], event: MouseEvent | D3DragEvent<HTMLCanvasElement, undefined, Hovered>
-   * | D3ZoomEvent<HTMLCanvasElement, undefined> | undefined) => void`.
+   * The point index will be passed as the first argument, position as the second argument,
+   * the corresponding mouse event or D3's zoom event as the third argument, and whether
+   * the hovered point is selected as the fourth argument:
+   * `(index: number, pointPosition: [number, number], event: MouseEvent | D3DragEvent<HTMLCanvasElement, undefined, Hovered> | D3ZoomEvent<HTMLCanvasElement, undefined> | undefined, isSelected: boolean) => void`.
    * Default value: `undefined`
    */
   onPointMouseOver?: (
     index: number,
     pointPosition: [number, number],
-    event: MouseEvent | D3DragEvent<HTMLCanvasElement, undefined, Hovered> | D3ZoomEvent<HTMLCanvasElement, undefined> | undefined
+    event: MouseEvent | D3DragEvent<HTMLCanvasElement, undefined, Hovered> | D3ZoomEvent<HTMLCanvasElement, undefined> | undefined,
+    isSelected: boolean
   ) => void;
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1944,7 +1944,8 @@ export class Graph {
       this.config.onPointMouseOver?.(
         this.store.hoveredPoint.index,
         this.store.hoveredPoint.position,
-        this.currentEvent
+        this.currentEvent,
+        this.store.selectedIndices?.includes(this.store.hoveredPoint.index) ?? false
       )
     }
     if (isMouseout) this.config.onPointMouseOut?.(this.currentEvent)

--- a/src/modules/Points/find-hovered-point.vert
+++ b/src/modules/Points/find-hovered-point.vert
@@ -7,6 +7,7 @@ in vec2 pointIndices;
 in float size;
 
 uniform sampler2D positionsTexture;
+uniform sampler2D pointGreyoutStatus;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform findHoveredPointUniforms {
@@ -19,6 +20,8 @@ layout(std140) uniform findHoveredPointUniforms {
   vec2 mousePosition;
   float scalePointsOnZoom;
   float maxPointSize;
+  float skipSelected;
+  float skipUnselected;
 } findHoveredPoint;
 
 #define pointsTextureSize findHoveredPoint.pointsTextureSize
@@ -30,6 +33,8 @@ layout(std140) uniform findHoveredPointUniforms {
 #define mousePosition findHoveredPoint.mousePosition
 #define scalePointsOnZoom findHoveredPoint.scalePointsOnZoom
 #define maxPointSize findHoveredPoint.maxPointSize
+#define skipSelected findHoveredPoint.skipSelected
+#define skipUnselected findHoveredPoint.skipUnselected
 #else
 uniform float pointsTextureSize;
 uniform float sizeScale;
@@ -40,6 +45,8 @@ uniform mat3 transformationMatrix;
 uniform vec2 mousePosition;
 uniform float scalePointsOnZoom;
 uniform float maxPointSize;
+uniform float skipSelected;
+uniform float skipUnselected;
 #endif
 
 out vec4 rgba;
@@ -61,6 +68,22 @@ float euclideanDistance (float x1, float x2, float y1, float y2) {
 }
 
 void main() {
+  vec4 greyoutStatus = texture(pointGreyoutStatus, (pointIndices + 0.5) / pointsTextureSize);
+  float isSelected = (greyoutStatus.r == 0.0) ? 1.0 : 0.0;
+
+  if (skipSelected > 0.0 && isSelected > 0.0) {
+    rgba = vec4(0.0);
+    gl_Position = vec4(0.5, 0.5, 0.0, 1.0);
+    gl_PointSize = 1.0;
+    return;
+  }
+  if (skipUnselected > 0.0 && isSelected <= 0.0) {
+    rgba = vec4(0.0);
+    gl_Position = vec4(0.5, 0.5, 0.0, 1.0);
+    gl_PointSize = 1.0;
+    return;
+  }
+
   vec4 pointPosition = texture(positionsTexture, (pointIndices + 0.5) / pointsTextureSize);
   vec2 point = pointPosition.rg;
 

--- a/src/stories/2. configuration.mdx
+++ b/src/stories/2. configuration.mdx
@@ -103,7 +103,7 @@ cosmos.gl layout algorithm was inspired by the [d3-force](https://github.com/d3/
 | onLinkContextMenu | Called when a context menu trigger occurs on a link, with link index |
 | onBackgroundContextMenu | Called when a context menu trigger occurs on the background (empty space) |
 | onMouseMove | Called on mouse movement with hover info |
-| onPointMouseOver | Called when pointer enters a point |
+| onPointMouseOver | Called when pointer enters a point, with index, position, event, and whether the point is selected |
 | onPointMouseOut | Called when pointer leaves a point |
 | onLinkMouseOver | Called when pointer enters a link |
 | onLinkMouseOut | Called when pointer leaves a link |


### PR DESCRIPTION
When some points are selected, they are drawn on top of unselected ones. Hover detection still used index order, so when points overlapped the wrong point could be reported (e.g. a high index instead of the selected one on top).

**Fix:** Use the same two-pass order for the hover pass as for drawing (unselected first, then selected), so the top-most point is the one that gets the hover.

Fixes #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Point hover callbacks now include selection status information, allowing developers to distinguish between selected and unselected points during hover interactions.

* **Improvements**
  * Enhanced point rendering with optimized two-pass rendering for better visual feedback on selected and unselected points.

* **Documentation**
  * Updated callback documentation to reflect the new selection status parameter in hover events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->