### PR TITLE
Beta Release 3.0.0-beta.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cosmos.gl/graph",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cosmos.gl/graph",
-      "version": "3.0.0-beta.6",
+      "version": "3.0.0-beta.7",
       "license": "MIT",
       "dependencies": {
         "@luma.gl/core": "^9.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmos.gl/graph",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "description": "GPU-based force graph layout and rendering",
   "jsdelivr": "dist/index.min.js",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

This PR prepares the `3.0.0-beta.7` release and includes all changes since `3.0.0-beta.6`.

## Breaking Changes

- `setConfig()` now resets the graph config back to default values before applying the provided fields. Projects that previously used `setConfig()` for incremental updates must switch those calls to `setConfigPartial()`.
- RGBA tuple config values now expect normalized channel values in the `0..1` range instead of `0..255`. This affects tuple-based color config fields such as `backgroundColor`, `pointDefaultColor`, `pointGreyoutColor`, `hoveredPointRingColor`, `focusedPointRingColor`, `outlinedPointRingColor`, `linkDefaultColor`, and `hoveredLinkColor`.
- `GraphConfigInterface` is no longer the public config type to import. Consumers should use `GraphConfig`.
- `enableSimulation`, `initialZoomLevel`, `randomSeed`, and `attribution` are now treated as init-only config fields and are no longer updated at runtime through `setConfig()` or `setConfigPartial()`.
- `getClusterPositions()` should now be treated as readonly. Consumer code should not mutate the returned array.

## Features

- Added `setConfigPartial()` for true partial config updates without resetting all other values.
- Added `pointDefaultShape` config support so projects can define the fallback point shape when per-point shapes are not provided. The default value is `PointShape.Circle`.
- Extended `pointDefaultShape` to accept a `PointShape` enum value, a numeric value, or a numeric string.
- Added an `enableSimulation` argument to programmatic zoom/view methods such as `zoom()`, `setZoomLevel()`, `fitView()`, `fitViewByPointIndices()`, `fitViewByPointPositions()`, `setZoomTransformByPointPositions()`, and `zoomToPointByIndex()`.  It defaults to `true`, allowing callers to explicitly control whether simulation runs during those transitions.

## Fixes and Behavior Improvements

- Preserved hovered state on `render()`.
- Improved hover detection, hover rings, and area selection so image size is considered together with shape size.
- Included image size in hover shader output so image-backed points behave more accurately.
- Cached cluster centroid positions while simulation is inactive to avoid redundant GPU work and readbacks.

## Upgrade Prompt

<details>
<summary>Upgrade prompt for projects using <code>3.0.0-beta.6</code></summary>

```text
Please upgrade this project from `@cosmos.gl/graph` `3.0.0-beta.6` to `3.0.0-beta.7`.

Focus on the API and behavior changes introduced between these versions:

1. `setConfig()` is now a reset-to-defaults operation.
   - Find all places where `setConfig()` is used for partial or incremental updates.
   - Replace those calls with `setConfigPartial()` when the intent is to preserve existing config values.

2. RGBA tuple colors must now use normalized values in the `0..1` range instead of `0..255`.
   - Find tuple-based color config values such as `backgroundColor`, `pointDefaultColor`, `pointGreyoutColor`, `hoveredPointRingColor`, `focusedPointRingColor`, `outlinedPointRingColor`, `linkDefaultColor`, and `hoveredLinkColor`.
   - Convert any `[r, g, b, a]` tuples using `0..255` RGB values into normalized tuples.

3. `GraphConfigInterface` is no longer the public config type.
   - Replace imports and usages of `GraphConfigInterface` with `GraphConfig`.

4. Some config fields are now init-only.
   - Check whether `enableSimulation`, `initialZoomLevel`, `randomSeed`, or `attribution` are being changed after graph creation through `setConfig()` or `setConfigPartial()`.
   - Refactor those to be provided only during `new Graph(...)` initialization.

5. `getClusterPositions()` should be treated as readonly.
   - Find code that mutates the returned array in place and change it to work on a copied array instead.

6. There are new optional capabilities you may adopt where useful.
   - Consider whether `pointDefaultShape` should be set in config. If it is not set, the default is `PointShape.Circle`.
   - Consider whether programmatic zoom calls should pass the new `enableSimulation` argument explicitly. If omitted, it defaults to `true`.

Please:
- search the codebase for affected usages,
- make the necessary code changes,
- summarize every migration you applied,
- list any locations that need manual review,
- and call out any ambiguous cases before changing them.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to `3.0.0-beta.7`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->