### PR TITLE
Swap position FBO before writing to fix stale reads

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1638,39 +1638,51 @@ export class Graph {
 
     // Right-click repulsion (runs regardless of isSimulationRunning)
     if (this.isRightClickMouse && this.config.enableRightClickRepulsion) {
+      this.points?.swapFbo()
       this.forceMouse?.run()
       this.points?.updatePosition()
     }
 
-    // Main simulation forces
-    // If forceExecution is true (from step()), always run
-    // Otherwise, respect isSimulationRunning and zoom state
+    // Main simulation forces gate:
+    // If forceExecution is true (from step()), always run.
+    // Otherwise, respect isSimulationRunning and zoom state.
     const enableSimulationDuringZoom = this.zoomInstance.shouldEnableSimulationDuringZoomOverride ?? this.config.enableSimulationDuringZoom
     const shouldRunSimulation = forceExecution ||
       (isSimulationRunning && !(this.zoomInstance.isRunning && !enableSimulationDuringZoom))
 
+    // Swap-before-write: every GPU position write is preceded by swapFbo(). The swap makes
+    // `previous` point to the freshest data so updatePosition() reads it
+    // and writes the new result into `current`. After each swap+write pair
+    // `current` holds the latest positions — the draw pass, hover detection,
+    // trackPoints and the next frame all read from `current`.
     if (shouldRunSimulation) {
       if (simulationGravity) {
+        this.points?.swapFbo()
         this.forceGravity?.run()
         this.points?.updatePosition()
       }
 
       if (simulationCenter) {
+        this.points?.swapFbo()
         this.forceCenter?.run()
         this.points?.updatePosition()
       }
 
+      this.points?.swapFbo()
       this.forceManyBody?.run()
       this.points?.updatePosition()
 
       if (this.store.linksTextureSize) {
+        this.points?.swapFbo()
         this.forceLinkIncoming?.run()
         this.points?.updatePosition()
+        this.points?.swapFbo()
         this.forceLinkOutgoing?.run()
         this.points?.updatePosition()
       }
 
       if (this.graph.pointClusters || this.graph.clusterPositions) {
+        this.points?.swapFbo()
         this.clusters?.run()
         this.points?.updatePosition()
       }
@@ -1771,8 +1783,11 @@ export class Graph {
       this.points?.draw(drawRenderPass)
 
       if (this.dragInstance.isActive) {
-        // To prevent the dragged point from suddenly jumping, run the drag function twice
-        this.points?.drag()
+        // Swap-before-write: after the swap, `previous` holds the freshest positions so drag()
+        // reads those and writes the drag result into `current`. This runs
+        // after points.draw() above — the drag result becomes visible on
+        // the next frame; trackPoints() picks it up immediately below.
+        this.points?.swapFbo()
         this.points?.drag()
         // Update tracked positions after drag, even when simulation is disabled
         this.points?.trackPoints()

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -1585,7 +1585,9 @@ export class Points extends CoreModule {
     this.updatePositionCommand.draw(renderPass)
     renderPass.end()
 
-    this.swapFbo()
+    // swapFbo() must be called before this method so that
+    // `previousPositionTexture` holds the freshest positions for the shader
+    // to read. After this call, `currentPositionFbo` holds the new result.
     // Invalidate tracked positions cache since positions have changed
     this.isPositionsUpToDate = false
   }
@@ -1612,7 +1614,9 @@ export class Points extends CoreModule {
     this.dragPointCommand.draw(renderPass)
     renderPass.end()
 
-    this.swapFbo()
+    // swapFbo() must be called before this method so that
+    // `previousPositionTexture` holds the freshest positions for the shader
+    // to read. After this call, `currentPositionFbo` holds the drag result.
     // Invalidate tracked positions cache since positions have changed
     this.isPositionsUpToDate = false
   }
@@ -2200,7 +2204,7 @@ export class Points extends CoreModule {
     this.trackPointsVertexCoordBuffer = undefined
   }
 
-  private swapFbo (): void {
+  public swapFbo (): void {
     // Swap textures and framebuffers
     // Safety check: ensure resources exist and aren't destroyed before swapping
     if (!this.currentPositionTexture || this.currentPositionTexture.destroyed ||


### PR DESCRIPTION
`currentPositionTexture` should always hold the latest positions, but the old swap logic broke that:

**Before (swap after write):**
```
force.run()
updatePosition()  → writes to current, then swaps
                  → current = stale, previous = fresh ❌
```

**After (swap before write):**
```
swapFbo()         → previous = fresh (was current)
force.run()
updatePosition()  → writes to current
                  → current = fresh ✓
```

The old order left `currentPositionTexture` stale between writes, causing points to jump on click and unpredictable drag behavior (#133).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the sequencing of position updates during force simulation to ensure each calculation step uses the most current data from previous calculations, improving overall correctness of the physics simulation
  * Improved drag interaction responsiveness by adjusting when position changes are committed, so updates are immediately reflected during the same interaction frame

<!-- end of auto-generated comment: release notes by coderabbit.ai -->