### PR TITLE
Add missing @luma.gl/shadertools dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@luma.gl/core": "^9.2.6",
         "@luma.gl/engine": "^9.2.6",
+        "@luma.gl/shadertools": "^9.2.6",
         "@luma.gl/webgl": "^9.2.6",
         "d3-array": "^3.2.0",
         "d3-color": "^3.1.0",
@@ -817,11 +818,10 @@
       }
     },
     "node_modules/@luma.gl/shadertools": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.2.3.tgz",
-      "integrity": "sha512-NQYWZk6oY3nMUV5iyv8ChnU9K48Yrp7mi6eofTi4Y42LEDLvm+808f2pm4sI1wPpvqSiuMr/l7nYyoQXH10/BA==",
+      "version": "9.2.6",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.2.6.tgz",
+      "integrity": "sha512-4+uUbynqPUra9d/z1nQChyHmhLgmKfSMjS7kOwLB6exSnhKnpHL3+Hu9fv55qyaX50nGH3oHawhGtJ6RRvu65w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@math.gl/core": "^4.1.0",
         "@math.gl/types": "^4.1.0",
@@ -9785,8 +9785,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/wgsl_reflect/-/wgsl_reflect-1.2.3.tgz",
       "integrity": "sha512-BQWBIsOn411M+ffBxmA6QRLvAOVbuz3Uk4NusxnqC1H7aeQcVLhdA3k2k/EFFFtqVjhz3z7JOOZF1a9hj2tv4Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -10378,10 +10377,9 @@
       }
     },
     "@luma.gl/shadertools": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.2.3.tgz",
-      "integrity": "sha512-NQYWZk6oY3nMUV5iyv8ChnU9K48Yrp7mi6eofTi4Y42LEDLvm+808f2pm4sI1wPpvqSiuMr/l7nYyoQXH10/BA==",
-      "peer": true,
+      "version": "9.2.6",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.2.6.tgz",
+      "integrity": "sha512-4+uUbynqPUra9d/z1nQChyHmhLgmKfSMjS7kOwLB6exSnhKnpHL3+Hu9fv55qyaX50nGH3oHawhGtJ6RRvu65w==",
       "requires": {
         "@math.gl/core": "^4.1.0",
         "@math.gl/types": "^4.1.0",
@@ -16599,8 +16597,7 @@
     "wgsl_reflect": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/wgsl_reflect/-/wgsl_reflect-1.2.3.tgz",
-      "integrity": "sha512-BQWBIsOn411M+ffBxmA6QRLvAOVbuz3Uk4NusxnqC1H7aeQcVLhdA3k2k/EFFFtqVjhz3z7JOOZF1a9hj2tv4Q==",
-      "peer": true
+      "integrity": "sha512-BQWBIsOn411M+ffBxmA6QRLvAOVbuz3Uk4NusxnqC1H7aeQcVLhdA3k2k/EFFFtqVjhz3z7JOOZF1a9hj2tv4Q=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@luma.gl/core": "^9.2.6",
     "@luma.gl/engine": "^9.2.6",
+    "@luma.gl/shadertools": "^9.2.6",
     "@luma.gl/webgl": "^9.2.6",
     "d3-array": "^3.2.0",
     "d3-color": "^3.1.0",


### PR DESCRIPTION
Adds `@luma.gl/shadertools` to `dependencies` in `package.json`.

Fixes cosmosgl/graph#223.

Thanks to @ZemyCode for reporting this and pinpointing the root cause! 🙏   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to improve project compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->