### PR TITLE
Add CLAUDE.md: agent/contributor guide to the codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md — agent/contributor guide for cosmos.gl
+
+`@cosmos.gl/graph` (cosmos.gl) is a GPU-accelerated force-graph **layout and rendering engine** for the
+browser: WebGL 2 (via luma.gl), with the force simulation and the drawing both running in GLSL shaders,
+built to render hundreds of thousands of points and links interactively. It renders node–link graphs
+(points + links) and pure point/scatter layouts (points, no links). TypeScript + GLSL; no backend.
+
+This file orients an AI agent (or a new contributor) to the codebase. For project governance and the
+contribution process, see `CONTRIBUTING.md`, `CHARTER.md`, `CODE_OF_CONDUCT.md`, and `GOVERNANCE.md`.
+
+## Codebase map (`src/`)
+
+- `index.ts` — public API: the `Graph` class and its data-ingest methods (`setPointPositions`,
+  `setLinks`, `setPointColors` / `setPointSizes` / `setPointShapes`, `setLinkColors` / `setLinkWidths`,
+  `setConfig`, …). JSDoc documents the exact typed-array layout each method expects.
+- `config.ts` — `GraphConfigInterface`: every configuration option (point/link styling, the
+  `simulation*` forces, zoom/interaction, sampling distances). `GraphConfig` is its `Partial`.
+- `variables.ts` — `defaultConfigValues`: the default value for every config key (typed to stay
+  exhaustive against `GraphConfigInterface`); the single source for defaults.
+- `modules/GraphData/` — the data model: the `PointShape` enum and the `GraphData` class, whose
+  `inputPoint*` / `inputLink*` fields enumerate every per-element channel the engine consumes, plus
+  validation and default-fill.
+- `modules/` — per-force and per-render modules (ForceManyBody, ForceLink, ForceGravity, ForceCenter,
+  ForceMouse, Clusters, Points, Lines, Zoom, Drag, Store), each with its GLSL shaders.
+- `stories/` — Storybook examples (beginners, clusters, shapes, geospatial, experiments) plus the
+  `configuration.mdx` / `api-reference.mdx` docs — the best worked examples of building the input arrays.
+- `helper.ts` — utilities (e.g. `getRgbaColor`: parse a CSS/hex color into a normalized RGBA tuple).
+
+`migration-notes.md` is the authoritative history of data-format and config changes (v1→v3: the move to
+`Float32Array` ingest, the v3 config renames, RGBA normalized to 0..1). Read it before touching the
+public API or config keys.
+
+## Data model in one paragraph
+
+The engine ingests **flat typed arrays**, not objects. `setPointPositions(Float32Array)` is
+`[x0, y0, x1, y1, …]` (point count = length / 2) and establishes the index space everything else aligns
+to; `setLinks(Float32Array)` is `[src0, tgt0, src1, tgt1, …]` of **point indices**. Per-element visual
+channels (colors as RGBA in 0..1, sizes, widths, shapes) are parallel arrays. Presence of links ⇒ a
+graph visualization; positions only ⇒ a point/scatter visualization.
+
+## Dev workflow
+
+Requires Node ≥ 18, npm ≥ 7.
+
+- `npm run storybook` — the primary dev loop (live examples at `:6006`). Per `CONTRIBUTING.md`, add or
+  update a Storybook example when you add a feature or change configuration / public methods.
+- `npm run build` — production build (Vite, ES + UMD).
+- `npm run watch` — rebuild on change.
+- `npm run lint` — ESLint over `src` (`lint-staged` runs on commit). **Ensure the project lints and
+  builds before opening a PR.**
+
+## Contributing
+
+Per `CONTRIBUTING.md`: fork, branch from `main`, code, make sure lint + build pass, add a Storybook
+example if you changed behavior/config/public API, then open a PR. Contributions are MIT-licensed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This repository uses `AGENTS.md` as the primary agent/contributor guide (readable by Claude Code, Codex, Cursor, and other tools). Claude Code users: the line below inlines it automatically.
+
+@AGENTS.md


### PR DESCRIPTION
Adds a short `CLAUDE.md` that orients an AI agent (or a new contributor) to the repo: a codebase map of `src/` (public API, config + defaults, the `GraphData` model, force/render modules, Storybook examples), a one-paragraph summary of the flat-`Float32Array` data model, the dev workflow (`npm run storybook`/`build`/`lint`, Node ≥18), and a pointer to `CONTRIBUTING.md`/`CHARTER.md` for process and governance. Documentation only — no code changes. Follows the `CONTRIBUTING.md` fork→branch→PR flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to a concise pointer to the primary contributor/agent guide.
  * Introduced a new contributor/agent guide covering project purpose, codebase orientation, expected typed-array data model for ingestion, and a development/contribution workflow checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->