### PR TITLE
Configurable link blending for faster rendering

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -260,6 +260,15 @@ export interface GraphConfigInterface {
    */
   scaleLinksOnZoom: boolean;
   /**
+   * Controls alpha blending for link rendering.
+   *
+   * When `true` (default), links are drawn with standard source-over alpha blending,
+   * which is required for transparency, opacity, and antialiased link edges.
+   * Disable if you want much faster links rendering.
+   * Default value: `true`
+   */
+  linkBlending: boolean;
+  /**
    * If set to true, links are rendered as curved lines.
    * Otherwise as straight lines.
    * Default value: `false`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1548,6 +1548,9 @@ export class Graph {
       this.graph.updateArrows()
       this.lines?.updateArrow()
     }
+    if (prevConfig.linkBlending !== this.config.linkBlending) {
+      this.lines?.updateLinkBlending()
+    }
     if (prevConfig.curvedLinkSegments !== this.config.curvedLinkSegments ||
       prevConfig.curvedLinks !== this.config.curvedLinks) {
       this.lines?.updateCurveLineGeometry()

--- a/src/modules/Lines/draw-curve-line.frag
+++ b/src/modules/Lines/draw-curve-line.frag
@@ -49,11 +49,8 @@ void main() {
   } else opacity = rgbaColor.a * smoothstep(0.5, 0.5 - smoothing, abs(pos.y));
   
   if (renderMode > 0.0) {
-    if (opacity > 0.0) {
-      fragColor = vec4(linkIndex, 0.0, 0.0, 1.0);
-    } else {
-      fragColor = vec4(-1.0, 0.0, 0.0, 0.0);
-    }
+    if (opacity <= 0.0) discard;
+    fragColor = vec4(linkIndex, 0.0, 0.0, 1.0);
   } else fragColor = vec4(color, opacity);
 
 }

--- a/src/modules/Lines/index.ts
+++ b/src/modules/Lines/index.ts
@@ -1,4 +1,4 @@
-import { Framebuffer, Buffer, Texture, UniformStore, RenderPass } from '@luma.gl/core'
+import { Framebuffer, Buffer, Texture, UniformStore, RenderPass, type RenderPipelineParameters } from '@luma.gl/core'
 import { Model } from '@luma.gl/engine'
 import { CoreModule } from '@/graph/modules/core-module'
 import type { Mat4Array } from '@/graph/modules/Store'
@@ -23,6 +23,7 @@ export class Lines extends CoreModule {
   public linkStatusTexture: Texture | undefined
   private linkStatusTextureSize = 0
   private drawCurveCommand: Model | undefined
+  private isLinkBlendingActive: boolean | undefined
   private hoveredLineIndexCommand: Model | undefined
   private fillSampledLinksFboCommand: Model | undefined
   private pointABuffer: Buffer | undefined
@@ -260,19 +261,10 @@ export class Lines extends CoreModule {
          * - No blending occurs - it's like drawing with a permanent marker
          * - This preserves the exact index values we need for picking/selection
          */
-      parameters: {
-        cullMode: 'back',
-        blend: true,
-        blendColorOperation: 'add',
-        blendColorSrcFactor: 'src-alpha',
-        blendColorDstFactor: 'one-minus-src-alpha',
-        blendAlphaOperation: 'add',
-        blendAlphaSrcFactor: 'one',
-        blendAlphaDstFactor: 'one-minus-src-alpha',
-        depthWriteEnabled: false,
-        depthCompare: 'always',
-      },
+      parameters: this.getLinkBlendParameters(this.config.linkBlending),
     })
+
+    this.isLinkBlendingActive = this.config.linkBlending
 
     // Initialize quad buffer for full-screen rendering
     this.quadBuffer ||= device.createBuffer({
@@ -382,6 +374,8 @@ export class Lines extends CoreModule {
     if (!this.arrowBuffer) this.updateArrow()
     if (!this.curveLineGeometry) this.updateCurveLineGeometry()
     if (!this.drawCurveCommand || !this.drawLineUniformStore || !this.linkStatusTexture) return
+
+    this.updateLinkBlending()
 
     const hasHighlighting = config.highlightedLinkIndices !== undefined
 
@@ -772,6 +766,17 @@ export class Lines extends CoreModule {
     }
   }
 
+  /**
+   * Re-applies the blend state to the link pipelines when `linkBlending` changes.
+   * `setParameters` can trigger a pipeline rebuild, so this only runs on an actual change.
+   */
+  public updateLinkBlending (): void {
+    const blend = this.config.linkBlending
+    if (blend === this.isLinkBlendingActive) return
+    this.drawCurveCommand?.setParameters(this.getLinkBlendParameters(blend))
+    this.isLinkBlendingActive = blend
+  }
+
   public getSampledLinkPositionsMap (): Map<number, [number, number, number]> {
     const positions = new Map<number, [number, number, number]>()
     if (!this.sampledLinksFbo || this.sampledLinksFbo.destroyed) return positions
@@ -874,6 +879,8 @@ export class Lines extends CoreModule {
     if (!this.linkIndexFbo || !this.drawCurveCommand || !this.drawLineUniformStore || !this.linkStatusTexture) return
     if (!this.linkIndexTexture || this.linkIndexTexture.destroyed) return
 
+    this.updateLinkBlending()
+
     const hasHighlighting = config.highlightedLinkIndices !== undefined
 
     // Update uniforms for index rendering
@@ -964,6 +971,7 @@ export class Lines extends CoreModule {
     // 1. Destroy Models FIRST (they destroy _gpuGeometry if exists, and _uniformStore)
     this.drawCurveCommand?.destroy()
     this.drawCurveCommand = undefined
+    this.isLinkBlendingActive = undefined
     this.hoveredLineIndexCommand?.destroy()
     this.hoveredLineIndexCommand = undefined
     this.fillSampledLinksFboCommand?.destroy()
@@ -1048,6 +1056,30 @@ export class Lines extends CoreModule {
       this.quadBuffer.destroy()
     }
     this.quadBuffer = undefined
+  }
+
+  /**
+   * Builds the render pipeline parameters for the link draw commands.
+   * With `blend` enabled, uses standard source-over alpha blending; with it disabled,
+   * fragments overwrite the framebuffer directly (no ROP read-modify-write).
+   */
+  private getLinkBlendParameters (blend: boolean): RenderPipelineParameters {
+    const base: RenderPipelineParameters = {
+      cullMode: 'back',
+      depthWriteEnabled: false,
+      depthCompare: 'always',
+    }
+    if (!blend) return { ...base, blend: false }
+    return {
+      ...base,
+      blend: true,
+      blendColorOperation: 'add',
+      blendColorSrcFactor: 'src-alpha',
+      blendColorDstFactor: 'one-minus-src-alpha',
+      blendAlphaOperation: 'add',
+      blendAlphaSrcFactor: 'one',
+      blendAlphaDstFactor: 'one-minus-src-alpha',
+    }
   }
 
   // Creates a 1×1 placeholder texture for the linkStatus sampler if none exists.

--- a/src/modules/Lines/index.ts
+++ b/src/modules/Lines/index.ts
@@ -16,6 +16,18 @@ import { getBytesPerRow } from '@/graph/modules/Shared/texture-utils'
 import { ensureVec2, ensureVec4 } from '@/graph/modules/Shared/uniform-utils'
 import { readPixels } from '@/graph/helper'
 
+type DrawCurveCommandAttributes = {
+  position?: Buffer;
+  pointA?: Buffer;
+  pointB?: Buffer;
+  sourceColor?: Buffer;
+  targetColor?: Buffer;
+  sourceWidth?: Buffer;
+  targetWidth?: Buffer;
+  arrow?: Buffer;
+  linkIndices?: Buffer;
+}
+
 export class Lines extends CoreModule {
   public linkIndexFbo: Framebuffer | undefined
   public hoveredLineIndexFbo: Framebuffer | undefined
@@ -23,6 +35,7 @@ export class Lines extends CoreModule {
   public linkStatusTexture: Texture | undefined
   private linkStatusTextureSize = 0
   private drawCurveCommand: Model | undefined
+  private drawCurvePickingCommand: Model | undefined
   private isLinkBlendingActive: boolean | undefined
   private hoveredLineIndexCommand: Model | undefined
   private fillSampledLinksFboCommand: Model | undefined
@@ -214,57 +227,16 @@ export class Lines extends CoreModule {
       },
     })
 
-    this.drawCurveCommand ||= new Model(device, {
-      vs: drawLineVert,
-      fs: drawLineFrag,
-      modules: [conicParametricCurveModule],
-      topology: 'triangle-strip',
-      vertexCount: this.curveLineGeometry?.length ?? 0,
-      attributes: {
-        ...this.curveLineBuffer && { position: this.curveLineBuffer },
-        ...this.pointABuffer && { pointA: this.pointABuffer },
-        ...this.pointBBuffer && { pointB: this.pointBBuffer },
-        ...this.sourceColorBuffer && { sourceColor: this.sourceColorBuffer },
-        ...this.targetColorBuffer && { targetColor: this.targetColorBuffer },
-        ...this.sourceWidthBuffer && { sourceWidth: this.sourceWidthBuffer },
-        ...this.targetWidthBuffer && { targetWidth: this.targetWidthBuffer },
-        ...this.arrowBuffer && { arrow: this.arrowBuffer },
-        ...this.linkIndexBuffer && { linkIndices: this.linkIndexBuffer },
-      },
-      bufferLayout: [
-        { name: 'position', format: 'float32x2' },
-        { name: 'pointA', format: 'float32x2', stepMode: 'instance' },
-        { name: 'pointB', format: 'float32x2', stepMode: 'instance' },
-        { name: 'sourceColor', format: 'float32x4', stepMode: 'instance' },
-        { name: 'targetColor', format: 'float32x4', stepMode: 'instance' },
-        { name: 'sourceWidth', format: 'float32', stepMode: 'instance' },
-        { name: 'targetWidth', format: 'float32', stepMode: 'instance' },
-        { name: 'arrow', format: 'float32', stepMode: 'instance' },
-        { name: 'linkIndices', format: 'float32', stepMode: 'instance' },
-      ],
-      defines: {
-        USE_UNIFORM_BUFFERS: true,
-      },
-      bindings: {
-        // Create uniform buffer binding
-        // Update it later by calling uniformStore.setUniforms()
-        drawLineUniforms: this.drawLineUniformStore.getManagedUniformBuffer(device, 'drawLineUniforms'),
-        drawLineFragmentUniforms: this.drawLineUniformStore.getManagedUniformBuffer(device, 'drawLineFragmentUniforms'),
-        // All texture bindings will be set dynamically in draw() method
-      },
-      /**
-         * Blending behavior for link index rendering (renderMode: 1.0 - hover detection):
-         *
-         * When rendering link indices to the framebuffer, we use full opacity (1.0).
-         * This means:
-         * - The source color completely overwrites the destination
-         * - No blending occurs - it's like drawing with a permanent marker
-         * - This preserves the exact index values we need for picking/selection
-         */
-      parameters: this.getLinkBlendParameters(this.config.linkBlending),
-    })
+    this.drawCurveCommand ||= this.createDrawCurveCommand(this.getLinkBlendParameters(this.config.linkBlending))
 
     this.isLinkBlendingActive = this.config.linkBlending
+
+    this.drawCurvePickingCommand ||= this.createDrawCurveCommand({
+      cullMode: 'back',
+      depthWriteEnabled: false,
+      depthCompare: 'always',
+      blend: false,
+    })
 
     // Initialize quad buffer for full-screen rendering
     this.quadBuffer ||= device.createBuffer({
@@ -566,13 +538,11 @@ export class Lines extends CoreModule {
     } else {
       this.linkIndexBuffer.write(linkIndices)
     }
-    if (this.drawCurveCommand) {
-      this.drawCurveCommand.setAttributes({
-        pointA: this.pointABuffer,
-        pointB: this.pointBBuffer,
-        linkIndices: this.linkIndexBuffer,
-      })
-    }
+    this.setDrawCurveCommandAttributes({
+      pointA: this.pointABuffer,
+      pointB: this.pointBBuffer,
+      linkIndices: this.linkIndexBuffer,
+    })
     if (this.fillSampledLinksFboCommand) {
       this.fillSampledLinksFboCommand.setAttributes({
         pointA: this.pointABuffer,
@@ -601,12 +571,10 @@ export class Lines extends CoreModule {
     this.targetColorBuffer = target
     this.previousColorData = previous
 
-    if (this.drawCurveCommand) {
-      this.drawCurveCommand.setAttributes({
-        ...(this.sourceColorBuffer && { sourceColor: this.sourceColorBuffer }),
-        ...(this.targetColorBuffer && { targetColor: this.targetColorBuffer }),
-      })
-    }
+    this.setDrawCurveCommandAttributes({
+      ...(this.sourceColorBuffer && { sourceColor: this.sourceColorBuffer }),
+      ...(this.targetColorBuffer && { targetColor: this.targetColorBuffer }),
+    })
   }
 
   public updateWidth (): void {
@@ -625,12 +593,10 @@ export class Lines extends CoreModule {
     this.targetWidthBuffer = target
     this.previousWidthData = previous
 
-    if (this.drawCurveCommand) {
-      this.drawCurveCommand.setAttributes({
-        ...(this.sourceWidthBuffer && { sourceWidth: this.sourceWidthBuffer }),
-        ...(this.targetWidthBuffer && { targetWidth: this.targetWidthBuffer }),
-      })
-    }
+    this.setDrawCurveCommandAttributes({
+      ...(this.sourceWidthBuffer && { sourceWidth: this.sourceWidthBuffer }),
+      ...(this.targetWidthBuffer && { targetWidth: this.targetWidthBuffer }),
+    })
   }
 
   public updateArrow (): void {
@@ -662,11 +628,7 @@ export class Lines extends CoreModule {
         this.arrowBuffer.write(arrowData)
       }
     }
-    if (this.drawCurveCommand) {
-      this.drawCurveCommand.setAttributes({
-        arrow: this.arrowBuffer,
-      })
-    }
+    this.setDrawCurveCommandAttributes({ arrow: this.arrowBuffer })
   }
 
   public updateLinkStatus (): void {
@@ -757,13 +719,9 @@ export class Lines extends CoreModule {
       this.curveLineBuffer.write(flatGeometry)
     }
 
-    // Update vertex count in model if it exists
-    if (this.drawCurveCommand) {
-      this.drawCurveCommand.setAttributes({
-        position: this.curveLineBuffer,
-      })
-      this.drawCurveCommand.setVertexCount(this.curveLineGeometry.length)
-    }
+    this.setDrawCurveCommandAttributes({ position: this.curveLineBuffer })
+    this.drawCurveCommand?.setVertexCount(this.curveLineGeometry.length)
+    this.drawCurvePickingCommand?.setVertexCount(this.curveLineGeometry.length)
   }
 
   /**
@@ -876,10 +834,8 @@ export class Lines extends CoreModule {
     if (!points) return
     if (!points.currentPositionTexture || points.currentPositionTexture.destroyed) return
     if (!this.data.linksNumber || !this.store.isLinkHoveringEnabled) return
-    if (!this.linkIndexFbo || !this.drawCurveCommand || !this.drawLineUniformStore || !this.linkStatusTexture) return
+    if (!this.linkIndexFbo || !this.drawCurvePickingCommand || !this.drawLineUniformStore || !this.linkStatusTexture) return
     if (!this.linkIndexTexture || this.linkIndexTexture.destroyed) return
-
-    this.updateLinkBlending()
 
     const hasHighlighting = config.highlightedLinkIndices !== undefined
 
@@ -919,13 +875,13 @@ export class Lines extends CoreModule {
     })
 
     // Update texture bindings dynamically
-    this.drawCurveCommand.setBindings({
+    this.drawCurvePickingCommand.setBindings({
       positionsTexture: points.currentPositionTexture,
       linkStatus: this.linkStatusTexture,
     })
 
     // Update instance count
-    this.drawCurveCommand.setInstanceCount(this.data.linksNumber ?? 0)
+    this.drawCurvePickingCommand.setInstanceCount(this.data.linksNumber ?? 0)
 
     // Render to index buffer for picking/hover detection
     const indexPass = this.device.beginRenderPass({
@@ -933,7 +889,7 @@ export class Lines extends CoreModule {
       // Clear framebuffer to transparent black (luma.gl default would be opaque black)
       clearColor: [0, 0, 0, 0],
     })
-    this.drawCurveCommand.draw(indexPass)
+    this.drawCurvePickingCommand.draw(indexPass)
     indexPass.end()
 
     if (this.hoveredLineIndexCommand && this.hoveredLineIndexFbo && this.hoveredLineIndexUniformStore) {
@@ -971,6 +927,8 @@ export class Lines extends CoreModule {
     // 1. Destroy Models FIRST (they destroy _gpuGeometry if exists, and _uniformStore)
     this.drawCurveCommand?.destroy()
     this.drawCurveCommand = undefined
+    this.drawCurvePickingCommand?.destroy()
+    this.drawCurvePickingCommand = undefined
     this.isLinkBlendingActive = undefined
     this.hoveredLineIndexCommand?.destroy()
     this.hoveredLineIndexCommand = undefined
@@ -1056,6 +1014,58 @@ export class Lines extends CoreModule {
       this.quadBuffer.destroy()
     }
     this.quadBuffer = undefined
+  }
+
+  private createDrawCurveCommand (parameters: RenderPipelineParameters): Model {
+    if (!this.drawLineUniformStore) {
+      throw new Error('Draw line uniforms must be initialized before creating link draw commands')
+    }
+    return new Model(this.device, {
+      vs: drawLineVert,
+      fs: drawLineFrag,
+      modules: [conicParametricCurveModule],
+      topology: 'triangle-strip',
+      vertexCount: this.curveLineGeometry?.length ?? 0,
+      attributes: this.getDrawCurveCommandAttributes(),
+      bufferLayout: [
+        { name: 'position', format: 'float32x2' },
+        { name: 'pointA', format: 'float32x2', stepMode: 'instance' },
+        { name: 'pointB', format: 'float32x2', stepMode: 'instance' },
+        { name: 'sourceColor', format: 'float32x4', stepMode: 'instance' },
+        { name: 'targetColor', format: 'float32x4', stepMode: 'instance' },
+        { name: 'sourceWidth', format: 'float32', stepMode: 'instance' },
+        { name: 'targetWidth', format: 'float32', stepMode: 'instance' },
+        { name: 'arrow', format: 'float32', stepMode: 'instance' },
+        { name: 'linkIndices', format: 'float32', stepMode: 'instance' },
+      ],
+      defines: {
+        USE_UNIFORM_BUFFERS: true,
+      },
+      bindings: {
+        drawLineUniforms: this.drawLineUniformStore.getManagedUniformBuffer(this.device, 'drawLineUniforms'),
+        drawLineFragmentUniforms: this.drawLineUniformStore.getManagedUniformBuffer(this.device, 'drawLineFragmentUniforms'),
+      },
+      parameters,
+    })
+  }
+
+  private getDrawCurveCommandAttributes (): DrawCurveCommandAttributes {
+    const attributes: DrawCurveCommandAttributes = {}
+    if (this.curveLineBuffer) attributes.position = this.curveLineBuffer
+    if (this.pointABuffer) attributes.pointA = this.pointABuffer
+    if (this.pointBBuffer) attributes.pointB = this.pointBBuffer
+    if (this.sourceColorBuffer) attributes.sourceColor = this.sourceColorBuffer
+    if (this.targetColorBuffer) attributes.targetColor = this.targetColorBuffer
+    if (this.sourceWidthBuffer) attributes.sourceWidth = this.sourceWidthBuffer
+    if (this.targetWidthBuffer) attributes.targetWidth = this.targetWidthBuffer
+    if (this.arrowBuffer) attributes.arrow = this.arrowBuffer
+    if (this.linkIndexBuffer) attributes.linkIndices = this.linkIndexBuffer
+    return attributes
+  }
+
+  private setDrawCurveCommandAttributes (attributes: DrawCurveCommandAttributes): void {
+    this.drawCurveCommand?.setAttributes(attributes)
+    this.drawCurvePickingCommand?.setAttributes(attributes)
   }
 
   /**

--- a/src/modules/Lines/index.ts
+++ b/src/modules/Lines/index.ts
@@ -231,13 +231,6 @@ export class Lines extends CoreModule {
 
     this.isLinkBlendingActive = this.config.linkBlending
 
-    this.drawCurvePickingCommand ||= this.createDrawCurveCommand({
-      cullMode: 'back',
-      depthWriteEnabled: false,
-      depthCompare: 'always',
-      blend: false,
-    })
-
     // Initialize quad buffer for full-screen rendering
     this.quadBuffer ||= device.createBuffer({
       data: new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]),
@@ -725,7 +718,7 @@ export class Lines extends CoreModule {
   }
 
   /**
-   * Re-applies the blend state to the link pipelines when `linkBlending` changes.
+   * Re-applies the blend state to the link pipeline when `linkBlending` changes.
    * `setParameters` can trigger a pipeline rebuild, so this only runs on an actual change.
    */
   public updateLinkBlending (): void {
@@ -834,8 +827,12 @@ export class Lines extends CoreModule {
     if (!points) return
     if (!points.currentPositionTexture || points.currentPositionTexture.destroyed) return
     if (!this.data.linksNumber || !this.store.isLinkHoveringEnabled) return
-    if (!this.linkIndexFbo || !this.drawCurvePickingCommand || !this.drawLineUniformStore || !this.linkStatusTexture) return
+    if (!this.linkIndexFbo || !this.drawLineUniformStore || !this.linkStatusTexture) return
     if (!this.linkIndexTexture || this.linkIndexTexture.destroyed) return
+
+    // Lazily create the picking command (only needed once hovering is in use). It is always
+    // unblended so the index pass writes exact link index values without blending corrupting them.
+    this.drawCurvePickingCommand ||= this.createDrawCurveCommand(this.getLinkBlendParameters(false))
 
     const hasHighlighting = config.highlightedLinkIndices !== undefined
 
@@ -1070,6 +1067,7 @@ export class Lines extends CoreModule {
 
   /**
    * Builds the render pipeline parameters for the link draw commands.
+   * Visible rendering follows `linkBlending`; picking passes `false`.
    * With `blend` enabled, uses standard source-over alpha blending; with it disabled,
    * fragments overwrite the framebuffer directly (no ROP read-modify-write).
    */

--- a/src/stories/2. configuration.mdx
+++ b/src/stories/2. configuration.mdx
@@ -46,6 +46,7 @@ All configuration properties are optional. When creating a graph or calling `set
 | focusedLinkIndex | Set focus on a link by index. The focused link will be rendered wider. When set to `undefined`, no link is focused. | `undefined` |
 | focusedLinkWidthIncrease | Number of pixels to add to the link width when focused | `5` |
 | scaleLinksOnZoom | Increase/decrease link width when zooming | `false` |
+| linkBlending | Controls alpha blending for link rendering. Disable for faster link rendering when transparency and antialiased link edges are not needed. | `true` |
 | curvedLinks | If set to true, links are rendered as curved lines. Otherwise as straight lines | `false` |
 | curvedLinkSegments | Number of segments in a curved line | `19` |
 | curvedLinkWeight | Weight affects the shape of the curve | `0.8` |

--- a/src/stories/beginners/link-hovering/index.ts
+++ b/src/stories/beginners/link-hovering/index.ts
@@ -18,6 +18,9 @@ export const linkHovering = (): { div: HTMLDivElement; graph: Graph; destroy?: (
     scalePointsOnZoom: true,
     linkDefaultArrows: false,
     curvedLinks: true,
+    // Alpha blending for links. Toggle it off with the checkbox to verify that
+    // link hover detection keeps working when transparency is disabled.
+    linkBlending: true,
     enableSimulation: false,
     hoveredLinkWidthIncrease: 4,
     attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmosgl-attribution-color);" target="_blank">Cosmograph</a>',
@@ -56,6 +59,39 @@ export const linkHovering = (): { div: HTMLDivElement; graph: Graph; destroy?: (
     display: none;
   `
   div.appendChild(infoPanel)
+
+  // Link blending toggle — disabling blending makes link rendering much faster.
+  // It's here so you can confirm hover detection still works without blending.
+  const blendingToggle = document.createElement('label')
+  blendingToggle.style.cssText = `
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: white;
+    font-size: 14px;
+    cursor: pointer;
+    user-select: none;
+  `
+
+  const blendingCheckbox = document.createElement('input')
+  blendingCheckbox.type = 'checkbox'
+  blendingCheckbox.checked = true
+  blendingCheckbox.style.cursor = 'pointer'
+
+  const blendingLabel = document.createElement('span')
+  blendingLabel.textContent = 'Link blending'
+
+  blendingToggle.appendChild(blendingCheckbox)
+  blendingToggle.appendChild(blendingLabel)
+  div.appendChild(blendingToggle)
+
+  blendingCheckbox.addEventListener('change', () => {
+    graph.setConfigPartial({ linkBlending: blendingCheckbox.checked })
+    graph.render()
+  })
 
   const destroy = (): void => {
     graph.destroy()

--- a/src/stories/stress-test.stories.ts
+++ b/src/stories/stress-test.stories.ts
@@ -1,0 +1,31 @@
+import type { Meta } from '@storybook/html'
+
+import { CosmosStoryProps } from '@/graph/stories/create-cosmos'
+import { createStory, Story } from '@/graph/stories/create-story'
+import { hyperbolicStressTest } from './stress-test'
+
+import hyperbolicStressTestStoryRaw from './stress-test/index?raw'
+import hyperbolicUtilsRaw from './utils?raw'
+
+const meta: Meta<CosmosStoryProps> = {
+  title: 'Examples/Stress Test',
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+}
+
+export const HyperbolicLargeGraph: Story = {
+  ...createStory(hyperbolicStressTest),
+  name: 'Hyperbolic Graph (140k points, ~1M links)',
+  parameters: {
+    sourceCode: [
+      { name: 'Story', code: hyperbolicStressTestStoryRaw },
+      { name: 'Generator', code: hyperbolicUtilsRaw },
+    ],
+  },
+}
+
+// eslint-disable-next-line import/no-default-export
+export default meta

--- a/src/stories/stress-test/index.ts
+++ b/src/stories/stress-test/index.ts
@@ -1,0 +1,125 @@
+import { Graph, type GraphConfig } from '@cosmos.gl/graph'
+
+import { generateHyperbolicGraph } from '../utils'
+
+const SPACE_SIZE = 4096
+const LINK_DEFAULT_WIDTH = 1
+
+/**
+ * Hyperbolic stress test — a synthetic large graph (~140k points, ~1M links)
+ * generated on the fly with a Hyperbolic Random Graph model (see
+ * `generateHyperbolicGraph`). Points are colored by their angular sector
+ * (emergent communities), sized by degree (hubs are larger), and start from a
+ * native disk layout that the GPU simulation refines.
+ */
+export const hyperbolicStressTest = (): { graph: Graph; div: HTMLDivElement; destroy?: () => void } => {
+  const div = document.createElement('div')
+  div.style.height = '100vh'
+  div.style.width = '100%'
+  div.style.position = 'relative'
+
+  let linkBlending = false
+
+  // Start / pause control for the simulation.
+  const toggleButton = document.createElement('button')
+  toggleButton.textContent = 'Pause'
+  toggleButton.style.cssText = [
+    'position: absolute',
+    'top: 12px',
+    'left: 12px',
+    'z-index: 1000',
+    'padding: 6px 16px',
+    'font: 600 13px Helvetica, Arial, sans-serif',
+    'color: #fff',
+    'background: #5f69de',
+    'border: none',
+    'border-radius: 15px',
+    'cursor: pointer',
+    'opacity: 0.9',
+  ].join(';')
+  div.appendChild(toggleButton)
+
+  const linkBlendingButton = document.createElement('button')
+  linkBlendingButton.textContent = 'Link blending: Off'
+  linkBlendingButton.style.cssText = [
+    'position: absolute',
+    'top: 48px',
+    'left: 12px',
+    'z-index: 1000',
+    'padding: 6px 16px',
+    'font: 600 13px Helvetica, Arial, sans-serif',
+    'color: #fff',
+    'background: #5f69de',
+    'border: none',
+    'border-radius: 15px',
+    'cursor: pointer',
+    'opacity: 0.9',
+  ].join(';')
+  div.appendChild(linkBlendingButton)
+
+  const { pointPositions, pointColors, pointSizes, links } = generateHyperbolicGraph({
+    nodeCount: 140_000,
+    avgDegree: 14,
+    alpha: 0.75,
+    spaceSize: SPACE_SIZE,
+    seed: 42,
+  })
+
+  const config: GraphConfig = {
+    spaceSize: SPACE_SIZE,
+    backgroundColor: '#2d313a',
+    pointDefaultSize: 1.5,
+    scalePointsOnZoom: true,
+    renderLinks: true,
+    linkDefaultColor: '#5F74C2',
+    linkDefaultWidth: LINK_DEFAULT_WIDTH,
+    linkGreyoutOpacity: 0,
+    linkBlending,
+    curvedLinks: false,
+    enableDrag: false,
+    fitViewOnInit: true,
+    fitViewDelay: 5000,
+    simulationFriction: 0.85,
+    simulationLinkSpring: 1,
+    simulationLinkDistance: 10,
+    simulationRepulsion: 0.5,
+    simulationGravity: 0.25,
+    simulationDecay: 100000,
+    showFPSMonitor: true,
+    attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmosgl-attribution-color);" target="_blank">Cosmograph</a>',
+  }
+
+  const graph = new Graph(div, config)
+
+  graph.setPointPositions(pointPositions)
+  graph.setPointColors(pointColors)
+  graph.setPointSizes(pointSizes)
+  graph.setLinks(links)
+  graph.render()
+  graph.start()
+
+  toggleButton.addEventListener('click', () => {
+    if (graph.isSimulationRunning) {
+      graph.pause()
+      toggleButton.textContent = 'Start'
+    } else {
+      graph.unpause()
+      toggleButton.textContent = 'Pause'
+    }
+  })
+
+  linkBlendingButton.addEventListener('click', () => {
+    linkBlending = !linkBlending
+    graph.setConfigPartial({
+      linkBlending,
+      linkDefaultWidth: linkBlending ? LINK_DEFAULT_WIDTH : LINK_DEFAULT_WIDTH / 2,
+    })
+    linkBlendingButton.textContent = `Link blending: ${linkBlending ? 'On' : 'Off'}`
+  })
+
+  const destroy = (): void => {
+    graph.destroy()
+  }
+
+  return { div, graph, destroy }
+}

--- a/src/stories/utils.ts
+++ b/src/stories/utils.ts
@@ -1,0 +1,201 @@
+/**
+ * Shared helpers for stories.
+ *
+ * `generateHyperbolicGraph` builds a Hyperbolic Random Graph (threshold model,
+ * T = 0). Nodes are sampled in the native 2D hyperbolic disk: a random angle
+ * and a radius drawn so that most nodes sit near the boundary and a few near
+ * the center. Two nodes are linked when their hyperbolic distance is <= R.
+ * This naturally yields a power-law degree distribution, high clustering, and
+ * emergent communities (angular sectors) — the structure that makes real
+ * networks look organic once force-laid-out.
+ *
+ * Efficiency: nodes are sorted by angle and each node only scans an angular
+ * window sized by its own radius, so each edge is found once from its more
+ * central endpoint. This keeps generation near O(N + E) — fine for ~1M edges.
+ */
+
+export interface HyperbolicOptions {
+  /** Number of nodes. */
+  nodeCount: number;
+  /** Target average degree (edges ≈ nodeCount * avgDegree / 2). */
+  avgDegree?: number;
+  /** Power-law exponent control. Must be > 0.5. Higher = steeper degree tail. */
+  alpha?: number;
+  /** Coordinate space size (match your GraphConfig.spaceSize). */
+  spaceSize?: number;
+  /** Optional seed for reproducibility. */
+  seed?: number;
+}
+
+export interface GeneratedGraphData {
+  pointPositions: Float32Array;
+  pointColors: Float32Array;
+  pointSizes: Float32Array;
+  links: Float32Array;
+}
+
+/** Mulberry32 PRNG — fast, seedable, good enough for graph generation. */
+function makeRng (seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function hslToRgb (h: number, s: number, l: number): [number, number, number] {
+  const k = (n: number): number => (n + h * 12) % 12
+  const a = s * Math.min(l, 1 - l)
+  const f = (n: number): number => l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)))
+  return [f(0), f(8), f(4)]
+}
+
+/** First index i where arr[i] >= value (lower_bound on a sorted slice). */
+function lowerBound (arr: Float64Array, value: number, n: number): number {
+  let lo = 0
+  let hi = n
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1
+    if (arr[mid]! < value) lo = mid + 1
+    else hi = mid
+  }
+  return lo
+}
+
+export function generateHyperbolicGraph (options: HyperbolicOptions): GeneratedGraphData {
+  const N = options.nodeCount
+  const avgDegree = options.avgDegree ?? 14
+  const alpha = Math.max(0.5001, options.alpha ?? 0.75)
+  const spaceSize = options.spaceSize ?? 8192
+  const rng = makeRng(options.seed ?? 0x9e3779b9)
+
+  const TWO_PI = Math.PI * 2
+
+  // Derive disk radius R from the target average degree (Gugelmann/Krioukov approx).
+  const xi = (2 / Math.PI) * (alpha / (alpha - 0.5)) ** 2
+  const R = 2 * Math.log((xi * N) / avgDegree)
+  const coshR = Math.cosh(R)
+  const coshAR = Math.cosh(alpha * R)
+
+  // Sample coordinates and precompute cosh/sinh of each radius.
+  const theta = new Float64Array(N)
+  const radius = new Float64Array(N)
+  const coshr = new Float64Array(N)
+  const sinhr = new Float64Array(N)
+
+  for (let i = 0; i < N; i++) {
+    theta[i] = rng() * TWO_PI
+    const u = rng()
+    // Inverse CDF of ρ(r) ∝ α·sinh(α·r).
+    const r = Math.acosh(1 + u * (coshAR - 1)) / alpha
+    radius[i] = r
+    coshr[i] = Math.cosh(r)
+    sinhr[i] = Math.sinh(r)
+  }
+
+  // Sort node indices by angle for windowed neighbor scans.
+  const order = new Int32Array(N)
+  for (let i = 0; i < N; i++) order[i] = i
+  order.sort((a, b) => theta[a]! - theta[b]!)
+  const sortedAngles = new Float64Array(N)
+  for (let k = 0; k < N; k++) sortedAngles[k] = theta[order[k]!]!
+
+  // Growable edge buffer (flat [src, tgt, src, tgt, ...] indices).
+  let edges = new Float32Array(Math.ceil(N * avgDegree * 1.3))
+  let edgeLen = 0
+  const degree = new Float32Array(N)
+
+  const pushEdge = (a: number, b: number): void => {
+    if (edgeLen + 2 > edges.length) {
+      const next = new Float32Array(edges.length * 2)
+      next.set(edges)
+      edges = next
+    }
+    edges[edgeLen++] = a
+    edges[edgeLen++] = b
+    degree[a]!++
+    degree[b]!++
+  }
+
+  // Link i to candidate j; only accept the more-peripheral partner so each
+  // edge is created exactly once.
+  const tryLink = (i: number, j: number): void => {
+    if (j === i) return
+    const ri = radius[i]!
+    const rj = radius[j]!
+    if (rj < ri || (rj === ri && j <= i)) return
+    let dt = Math.abs(theta[i]! - theta[j]!)
+    if (dt > Math.PI) dt = TWO_PI - dt
+    const coshd = coshr[i]! * coshr[j]! - sinhr[i]! * sinhr[j]! * Math.cos(dt)
+    if (coshd <= coshR) pushEdge(i, j)
+  }
+
+  for (let i = 0; i < N; i++) {
+    const ri = radius[i]!
+    // Angular reach for node i, assuming partner radius == ri (the widest a
+    // valid more-peripheral partner can be).
+    let window: number
+    if (ri < 1e-9) {
+      window = Math.PI
+    } else {
+      const c = (coshr[i]! * coshr[i]! - coshR) / (sinhr[i]! * sinhr[i]!)
+      if (c <= -1) window = Math.PI
+      else if (c >= 1) window = 0
+      else window = Math.acos(c)
+    }
+
+    if (window <= 0) continue
+
+    if (window >= Math.PI) {
+      // Hub: scan everyone.
+      for (let j = 0; j < N; j++) tryLink(i, j)
+      continue
+    }
+
+    const a = theta[i]!
+    const lo = a - window
+    const hi = a + window
+    const scan = (from: number, to: number): void => {
+      let k = lowerBound(sortedAngles, from, N)
+      while (k < N && sortedAngles[k]! < to) {
+        tryLink(i, order[k]!)
+        k++
+      }
+    }
+    scan(Math.max(0, lo), Math.min(TWO_PI, hi))
+    if (lo < 0) scan(TWO_PI + lo, TWO_PI)
+    if (hi > TWO_PI) scan(0, hi - TWO_PI)
+  }
+
+  // Build point arrays. Position = native polar layout (hubs near center),
+  // color = angular sector (communities), size grows with degree.
+  const pointPositions = new Float32Array(N * 2)
+  const pointColors = new Float32Array(N * 4)
+  const pointSizes = new Float32Array(N)
+  const center = spaceSize / 2
+  const radialScale = (spaceSize / 2) * 0.92 / R
+
+  for (let i = 0; i < N; i++) {
+    const rr = radius[i]! * radialScale
+    pointPositions[i * 2] = center + rr * Math.cos(theta[i]!)
+    pointPositions[i * 2 + 1] = center + rr * Math.sin(theta[i]!)
+
+    const [cr, cg, cb] = hslToRgb(theta[i]! / TWO_PI, 0.6, 0.62)
+    pointColors[i * 4] = cr
+    pointColors[i * 4 + 1] = cg
+    pointColors[i * 4 + 2] = cb
+    pointColors[i * 4 + 3] = 1.0
+
+    pointSizes[i] = 1.2 + Math.sqrt(degree[i]!) * 0.6
+  }
+
+  return {
+    pointPositions,
+    pointColors,
+    pointSizes,
+    links: edges.subarray(0, edgeLen),
+  }
+}

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -42,6 +42,7 @@ export const defaultConfigValues = {
   linkGreyoutOpacity: 0.1,
   linkWidthScale: 1,
   scaleLinksOnZoom: false,
+  linkBlending: true,
   curvedLinks: false,
   curvedLinkSegments: 19,
   curvedLinkWeight: 0.8,


### PR DESCRIPTION
Rendering links with transparency is much less performant than rendering without it. For graphs that have many links, some users might want to disable blending for faster performance. This PR makes it possible.


https://github.com/user-attachments/assets/c776570e-cb4c-4552-a9d8-fd8fabac2480



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `linkBlending` graph configuration to control alpha blending for link rendering.
  * Added an “Examples/Stress Test” story with Pause/Start and a Link blending toggle.
  * Enabled `linkBlending` by default in the link hovering beginner example, with a runtime checkbox.

* **Improvements**
  * Improved link hover/picking by discarding non-visible fragments during index picking.
  * Updated link rendering to apply `linkBlending` changes dynamically (including using separate handling for normal rendering vs picking).

* **Documentation**
  * Documented `linkBlending` in configuration properties, including the default value (`true`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->