### PR TITLE
Add and remove points via NaN positions (with fade in/out)

### DIFF
--- a/history/2026/2026-06-27-nan-point-removal.md
+++ b/history/2026/2026-06-27-nan-point-removal.md
@@ -1,0 +1,159 @@
+<!-- suggested path: history/2026/2026-06-27-nan-point-removal.md -->
+
+# `NaN` positions for stable-identity point removal and addition
+
+**Commits:** 23ef59b, 8ed059f
+
+## Why
+
+A point's identity in cosmos.gl is its array index. Removing a point by shrinking
+the array renumbers every later point, and because the transition animates **per
+index**, they all slide into their neighbour's old spot. That's correct for the
+"compact" mental model, but callers who add/remove points wanted the opposite: the
+removed point disappears, the **rest hold still**, and adds/removes **animate**.
+
+This adds an opt-in way to express that, plus the engine work to make it safe. It's
+additive — compacting the array still works exactly as before.
+
+## The model: `NaN` tombstones
+
+Instead of compacting, set a removed point's **position to `NaN`** (a value a
+`Float32Array` can hold). The slot stays — identity is preserved — and `NaN` means
+"absent". Adding is the mirror: a slot crosses `NaN → real`.
+
+```ts
+// remove: point fades out, others don't move
+positions[i * 2] = NaN; positions[i * 2 + 1] = NaN
+graph.setPointPositions(positions)
+```
+
+## Fade in / out
+
+A `NaN` position alone fades a point out — the engine handles it:
+
+- **Freeze.** `interpolate-position.frag` can't `mix()` toward/from `NaN`, so it holds
+  the real side: freeze at source on exit, appear at target on enter. The dot never
+  moves; the fade is carried by **size/opacity**.
+- **Exit-target resolution** (per point, in `GraphData`): no size/color array (or
+  length mismatch) → exit default (size 0, transparent); a real value → use it
+  (custom exit); `NaN` → exit default. So a bare `setPointPositions(…NaN…)` fades to
+  nothing; passing size/color only *overrides the look*.
+- `setPointPositions` queues the size/color transitions itself (no-op when unchanged)
+  so the fade animates even without a `setPointSizes`/`setPointColors` call.
+
+| add (`NaN → real`) | remove (`real → NaN`) |
+|---|---|
+| grow + fade in | shrink + fade out |
+| fade in at full size | fade out at full size |
+| recolor in | recolor out |
+| snap in | snap out |
+
+## The exit texture (one signal for two pipelines)
+
+The fade freeze erases the `NaN` from the live position, so absence must be tracked
+as explicit engine state. A single per-point **exit texture** does it:
+`R = previous absence`, `G = current absence` (`1` = `NaN` position), rebuilt from
+positions in `Points.updateExit()`.
+
+- **Draw** (`draw-points.vert`): `exit = mix(R, G, transitionProgress)`, skip when
+  `exit >= 1`. Gated on `animatePositions` — outside a position transition it reads
+  settled `G`, so an unrelated color/size update can't replay the ramp.
+- **Physics**: read `G` to exclude absent points.
+
+`exit` is "how gone is this point, 0→1, animated across the transition" — `mix`
+blends from absence-at-start (`R`) to absence-now (`G`):
+
+| R (was) | G (now) | meaning | `exit` |
+|---|---|---|---|
+| 0 | 0 | stays present | `0` — drawn |
+| 0 | 1 | leaving | `0 → 1` — ramps out |
+| 1 | 0 | entering | `1 → 0` — ramps in |
+| 1 | 1 | stays gone | `1` — skipped |
+
+A leaving point stays drawn (`exit < 1`) through the fade and is dropped only at the
+end — that window is what lets you see it fade rather than blink out. Both channels
+are needed: a single "absent now" bit can't tell leaving from entering from stable.
+
+A fast path (`isExitTextureAllZero`) skips the rebuild + GPU upload when nothing is
+or was absent, so graphs that never use `NaN` pay ~nothing.
+
+## Simulation safety
+
+Forces are reductions over all points, so one `NaN` would poison the whole layout in
+a tick (centroid = Σ positions, etc.) and the integrator's `clamp(NaN)` could
+resurrect a dead point at (0,0). All position-reading passes now read the exit
+texture's `G` and skip absent points:
+
+- `update-position.frag` — leave absent points untouched (no integrate, no clamp).
+- `calculate-centermass.vert` (ForceCenter, Clusters) and `calculate-level.vert`
+  (ForceManyBody) — cull absent points from the centroid/grid.
+- `force-spring.ts` (ForceLink) — skip a spring to an absent point.
+
+Gravity/mouse/drag are per-point, so the integrator skip covers them. Works with the
+simulation on or off.
+
+## `setNextTransitionDuration(ms?)`
+
+New public method: a one-shot per-call override of `transitionDuration` for the next
+update only, then it auto-clears. `0` snaps. Mainly for **compaction** — after points
+fade out you drop the tombstones and renumber, which must snap (an animated renumber
+would re-introduce the slide); since the surviving points keep their coordinates, a
+snapped renumber shows zero movement.
+
+```ts
+graph.setNextTransitionDuration(0) // snap the next update only
+graph.setPointPositions(compacted)
+graph.setPointColors(compacted)    // same update → also snaps
+```
+
+A pending override wins even mid-animation (the `duration` getter returns it first),
+so it reliably snaps an update issued while another transition is still playing; the
+running animation keeps its own length (`step()` reads `activeDuration` directly).
+
+## Picking, highlight & sampling exclude absent points
+
+The fade freezes an absent point at its last real position (and `opacity`/`recolor`
+exits keep its size), so it stays "hittable" until fully gone. Every consumer that
+reads positions now reads the exit texture's `G` and skips absent points:
+
+- **hover** (`find-hovered-point.vert`) — no ring on a removed point,
+- **rect / polygon selection** (`find-points-in-rect`/`-in-polygon`),
+- **highlight / outline draw** (`draw-highlighted.vert`),
+- **point & link sampling** (`fill-sampled-points` / `fill-sampled-links`) — no
+  phantom sampled points or links to a removed endpoint.
+
+## Other fixes pulled in
+
+- `rescaleInitialNodePositions` excludes `NaN` points from the bounding box — a single
+  absent point used to collapse the whole layout (`Math.min(x, NaN) = NaN`). The
+  degenerate single-point box is also handled (centered instead of `NaN`-scaled).
+- `draw-curve-line.vert` skips a link with a `NaN` endpoint (would draw garbage
+  geometry otherwise).
+
+## Migration
+
+Non-breaking and additive — no API signatures changed, and graphs without `NaN`
+positions render and simulate identically. The only behavior change is that a `NaN`
+position went from *undefined/broken* to *a defined "absent" feature*. `NaN` in a
+size/color array still resolves to the config default for a **present** point; it
+only means the exit default for an **absent** (NaN-position) one.
+
+## Example
+
+`src/stories/beginners/add-remove-points` (Storybook: **Examples / Beginners → Add &
+Remove Points**) — a stable slot pool with `NaN` tombstones and a live data panel
+(active vs. tombstoned slots). Buttons demonstrate the full enter/exit matrix (each
+enter style mirroring an exit style), link add, and **Compact** (snapped renumber via
+`setNextTransitionDuration(0)`).
+
+## Out of scope (by design)
+
+- **Slot lifecycle / compaction** is the caller's, and cosmos does **not**
+  auto-compact — by design. Only the caller knows what indices are tied to (ids,
+  links, selection), so the engine renumbering underneath them would break those.
+  Callers reuse freed slots on add, or **Compact** when convenient.
+- **Link-level absence tracking** — intentionally not added; callers drop a removed
+  point's links, with the line shader as a safety net.
+- **Position tracking** (`getTrackedPointPositionsMap`) — a raw read-back of the
+  indices the caller asked for; caller-owned, left as-is. Drag is covered
+  transitively (hover never returns an absent point).

--- a/history/2026/2026-06-27-nan-point-removal.md
+++ b/history/2026/2026-06-27-nan-point-removal.md
@@ -156,8 +156,14 @@ enter style mirroring an exit style), link add, and **Compact** (snapped renumbe
   auto-compact — by design. Only the caller knows what indices are tied to (ids,
   links, selection), so the engine renumbering underneath them would break those.
   Callers reuse freed slots on add, or **Compact** when convenient.
-- **Link-level absence tracking** — intentionally not added; callers drop a removed
-  point's links, with the line shader as a safety net.
-- **Position tracking** (`getTrackedPointPositionsMap`) — a raw read-back of the
-  indices the caller asked for; caller-owned, left as-is. Drag is covered
-  transitively (hover never returns an absent point).
+- **Link-level absence tracking** — no per-link absence state; a link is as absent as
+  its endpoints. (Follow-up: the line shader fades a link out with the exit ramp of
+  its endpoints and excludes it from link picking, so callers only drop removed
+  points' links when they compact.)
+- ~~**Position tracking** (`getTrackedPointPositionsMap`) — caller-owned, left
+  as-is.~~ Superseded by a follow-up: read-backs are honest about absence. An absent
+  point is omitted from the tracked map, and reads back as `NaN` from
+  `getPointPositions` / `getTrackedPointPositionsArray` (slots kept for index
+  alignment) — never as its frozen last on-screen coordinate. `fitView` therefore
+  ignores absent points. Drag is covered transitively (hover never returns an absent
+  point).

--- a/history/2026/2026-06-27-nan-point-removal.md
+++ b/history/2026/2026-06-27-nan-point-removal.md
@@ -2,7 +2,8 @@
 
 # `NaN` positions for stable-identity point removal and addition
 
-**Commits:** 9931bd8, 3985df6, e0a2a0b, f1768c1, 9575554
+**Commits:** 9931bd8, 3985df6, e0a2a0b, f1768c1, 9575554, 12e8219, 04e5a64, 2b754a9,
+607df91, ae2d44e, 83e069f, 31f3289, 2488f26, 6b8e6a6
 
 ## Why
 
@@ -13,7 +14,10 @@ index**, they all slide into their neighbour's old spot. That's correct for the
 removed point disappears, the **rest hold still**, and adds/removes **animate**.
 
 This adds an opt-in way to express that, plus the engine work to make it safe. It's
-additive — compacting the array still works exactly as before.
+additive — compacting the array still works exactly as before. A deep review pass
+before release hardened the feature end to end (the later commits above): every
+consumer of positions — physics, picking, links, zoom, read-backs — now agrees on
+what "absent" means.
 
 ## The model: `NaN` tombstones
 
@@ -27,6 +31,13 @@ positions[i * 2] = NaN; positions[i * 2 + 1] = NaN
 graph.setPointPositions(positions)
 ```
 
+Absence means `NaN` in **either** coordinate, defined once: the shared
+`isPointAbsent` helper (`src/helper.ts`) is the CPU-side predicate, and
+`buildPositionTextureData` normalizes a half-NaN position to fully-NaN so the GPU
+never sees a partial one. (Before this, absence was keyed on `x` only at most sites —
+a point with a real `x` and `NaN` `y` passed every guard and its `NaN` cascaded
+through the spring/centroid sums until the whole layout died.)
+
 ## Fade in / out
 
 A `NaN` position alone fades a point out — the engine handles it:
@@ -34,12 +45,22 @@ A `NaN` position alone fades a point out — the engine handles it:
 - **Freeze.** `interpolate-position.frag` can't `mix()` toward/from `NaN`, so it holds
   the real side: freeze at source on exit, appear at target on enter. The dot never
   moves; the fade is carried by **size/opacity**.
-- **Exit-target resolution** (per point, in `GraphData`): no size/color array (or
-  length mismatch) → exit default (size 0, transparent); a real value → use it
-  (custom exit); `NaN` → exit default. So a bare `setPointPositions(…NaN…)` fades to
-  nothing; passing size/color only *overrides the look*.
-- `setPointPositions` queues the size/color transitions itself (no-op when unchanged)
-  so the fade animates even without a `setPointSizes`/`setPointColors` call.
+- **Read-time resolution.** Input size/color arrays are used **verbatim** — cosmos
+  never edits or copies them, so "use the default" stays encoded as `NaN` all the way
+  to the GPU. The draw shader resolves a `NaN` channel against the animated exit
+  ramp: `mix(configDefault, EXIT_DEFAULT, exit)` — the config default while present,
+  fading to the exit default (size 0, transparent) as the point leaves. Explicit
+  (real) values pass through: passing size/color *overrides the look* (custom exit).
+- Because the ramp drives the default fade itself, a removal needs **no size/color
+  transition**: `setPointPositions` queues only `Positions`, and **hover picking
+  stays live during bare-removal fades**. (A custom exit look calls
+  `setPointSizes`/`setPointColors`, whose transitions pause hover as they always
+  have.)
+- `EXIT_DEFAULT_SIZE` / `EXIT_DEFAULT_COLOR_CHANNEL` live once in `variables.ts`,
+  imported by the CPU mirrors (`GraphData.getResolvedPointSize`/
+  `getResolvedPointColorChannel` — used by collision sizing, rect-selection sizing,
+  the hover/focus ring, image-size fallback, read-backs) and injected into the
+  shader as `#define`s (formatted as exact float literals).
 
 | add (`NaN → real`) | remove (`real → NaN`) |
 |---|---|
@@ -53,11 +74,13 @@ A `NaN` position alone fades a point out — the engine handles it:
 The fade freeze erases the `NaN` from the live position, so absence must be tracked
 as explicit engine state. A single per-point **exit texture** does it:
 `R = previous absence`, `G = current absence` (`1` = `NaN` position), rebuilt from
-positions in `Points.updateExit()`.
+positions in `Points.updateExit()`. It is `rg32float` — two channels are all the
+state there is.
 
-- **Draw** (`draw-points.vert`): `exit = mix(R, G, transitionProgress)`, skip when
-  `exit >= 1`. Gated on `animatePositions` — outside a position transition it reads
-  settled `G`, so an unrelated color/size update can't replay the ramp.
+- **Draw** (`draw-points.vert`): `exit = mix(R, G, transitionProgress)` — skips the
+  point at `exit >= 1` and resolves `NaN` size/color channels along the ramp (above).
+  Gated on `animatePositions` — outside a position transition it reads settled `G`,
+  so an unrelated color/size update can't replay the ramp.
 - **Physics**: read `G` to exclude absent points.
 
 `exit` is "how gone is this point, 0→1, animated across the transition" — `mix`
@@ -74,23 +97,36 @@ A leaving point stays drawn (`exit < 1`) through the fade and is dropped only at
 end — that window is what lets you see it fade rather than blink out. Both channels
 are needed: a single "absent now" bit can't tell leaving from entering from stable.
 
-A fast path (`isExitTextureAllZero`) skips the rebuild + GPU upload when nothing is
-or was absent, so graphs that never use `NaN` pay ~nothing.
+While no point is (or was) absent — every graph that never uses `NaN` —
+`exitTexture` is a **1×1 all-zero stand-in**: any sample returns "present", the
+single texel stays cache-resident so the per-vertex fetch in the hot shaders costs
+~nothing, and the full-size texture is never allocated at all.
 
 ## Simulation safety
 
 Forces are reductions over all points, so one `NaN` would poison the whole layout in
 a tick (centroid = Σ positions, etc.) and the integrator's `clamp(NaN)` could
-resurrect a dead point at (0,0). All position-reading passes now read the exit
+resurrect a dead point at (0,0). All position-reading passes read the exit
 texture's `G` and skip absent points:
 
 - `update-position.frag` — leave absent points untouched (no integrate, no clamp).
 - `calculate-centermass.vert` (ForceCenter, Clusters) and `calculate-level.vert`
   (ForceManyBody) — cull absent points from the centroid/grid.
+- `build-grid.vert` (ForceCollision) — keep absent points out of the collision grid.
 - `force-spring.ts` (ForceLink) — skip a spring to an absent point.
 
 Gravity/mouse/drag are per-point, so the integrator skip covers them. Works with the
 simulation on or off.
+
+## Links follow their points
+
+A link is as absent as its endpoints — there is no per-link absence state.
+`draw-curve-line.vert` samples the exit texture for both endpoints: the visible pass
+multiplies link opacity by `(1 − exitA)(1 − exitB)` using the same animated ramp as
+the point fade (links fade out/in in sync with their endpoint), and the picking pass
+(`renderMode > 0`, same shader) drops a link as soon as an endpoint is currently
+absent — matching point picking. The `isnan` endpoint guard stays as a snap-path
+backstop. Callers only actually drop a removed point's links when they compact.
 
 ## `render(simulationAlpha?, transitionDuration?)`
 
@@ -106,49 +142,70 @@ graph.setPointColors(compactedColors)        // [r0, g0, b0, a0, …], same upda
 graph.render(undefined, 0)                    // snap this update only
 ```
 
-`render` sets the duration on the transition (`setDurationOverride`) before the update
-pipeline runs and `start()` consumes it. It must be visible in that window because the
-pipeline (`Points.updatePositions`) reads it to choose animate vs. snap *before* `start()`
-runs. Because `render` sets it before every `start()`, it can't carry into another render —
-the leak the earlier approach was prone to. A transition already playing keeps its own
-length (`step()` reads `activeDuration` directly). An earlier iteration exposed a stateful
-`setNextTransitionDuration(ms?)` setter; it was folded into this argument before release.
+Three durations, three scopes: `config.transitionDuration` (the default),
+the render override (this call only), and `activeDuration` (frozen at `start()`,
+pacing the running animation). The `duration` getter resolves the commit scope only
+(`override ?? config`) and `start()` consumes that same getter, so the pipeline's
+animate-vs-snap prediction can never disagree with what `start()` does. A transition
+already playing keeps its own length — which also means changing
+`config.transitionDuration` mid-flight no longer retimes (or cancels) a running
+transition; to end one immediately, apply an update with `render(undefined, 0)`.
+An earlier iteration exposed a stateful `setNextTransitionDuration(ms?)` setter; it
+was folded into this argument before release.
 
-## Picking, highlight & sampling exclude absent points
+## Absent points are gone everywhere
 
-The fade freezes an absent point at its last real position (and `opacity`/`recolor`
-exits keep its size), so it stays "hittable" until fully gone. Every consumer that
-reads positions now reads the exit texture's `G` and skips absent points:
+The fade freezes an absent point at its last real position, so without guards it
+would stay "hittable" and readable forever. Every consumer now agrees it is gone:
 
-- **hover** (`find-hovered-point.vert`) — no ring on a removed point,
+- **hover** (`find-hovered-point.vert`) — no ring on a removed point, and hover
+  stays live during bare-removal fades (a removal alone activates no size/color
+  transition),
 - **rect / polygon selection** (`find-points-in-rect`/`-in-polygon`),
 - **highlight / outline draw** (`draw-highlighted.vert`),
-- **point & link sampling** (`fill-sampled-points` / `fill-sampled-links`) — no
-  phantom sampled points or links to a removed endpoint.
+- **point & link sampling** (`fill-sampled-points` / `fill-sampled-links`),
+- **zoom / fitView** — `zoomToPointByIndex` is a no-op for an absent point, and the
+  camera math is total: `Zoom.getTransform`/`getMiddlePointTransform` skip non-finite
+  positions and keep the current view when no finite extent remains, so the canvas
+  transform can never go `NaN` (even with every point removed),
+- **read-backs** — `getPointPositions` / `getTrackedPointPositionsArray` report
+  `NaN` for absent slots (kept for index alignment); `getTrackedPointPositionsMap`
+  omits the key. The GPU texture intentionally keeps the frozen coordinate (the fade
+  renders from it); only the read-back layer reinterprets.
 
 ## Other fixes pulled in
 
 - `rescaleInitialNodePositions` excludes `NaN` points from the bounding box — a single
   absent point used to collapse the whole layout (`Math.min(x, NaN) = NaN`). The
-  degenerate single-point box is also handled (centered instead of `NaN`-scaled).
-- `draw-curve-line.vert` skips a link with a `NaN` endpoint (would draw garbage
-  geometry otherwise).
+  degenerate single-point box is handled (centered instead of `NaN`-scaled), and the
+  all-absent early return clears `scaleX`/`scaleY` so `getScaleX()`/`getScaleY()`
+  never report a previous dataset's mapping.
+- `getPointColors` / `getPointSizes` return an **as-rendered snapshot** computed on
+  demand (a new array, safe to mutate) instead of aliasing the live internal buffer.
 
 ## Migration
 
 Non-breaking and additive — no API signatures changed, and graphs without `NaN`
-positions render and simulate identically. The only behavior change is that a `NaN`
-position went from *undefined/broken* to *a defined "absent" feature*. `NaN` in a
-size/color array still resolves to the config default for a **present** point; it
-only means the exit default for an **absent** (NaN-position) one.
+positions render and simulate identically. Behavior notes:
+
+- A `NaN` position went from *undefined/broken* to *a defined "absent" feature*.
+- `NaN` in a size/color array still resolves to the config default for a **present**
+  point; it only means the exit default for an **absent** one — and since resolution
+  happens at read time, the caller's **size/color arrays are never modified**, so a
+  revived point's `NaN` channels re-resolve to config defaults as documented.
+  (Positions are unchanged from main: with `rescalePositions` enabled the engine
+  still writes scaled coordinates back into the positions array.)
+- Changing `config.transitionDuration` no longer affects a transition already
+  playing (it applies from the next one).
 
 ## Example
 
 `src/stories/beginners/add-remove-points` (Storybook: **Examples / Beginners → Add &
-Remove Points**) — a stable slot pool with `NaN` tombstones and a live data panel
-(active vs. tombstoned slots). Buttons demonstrate the full enter/exit matrix (each
-enter style mirroring an exit style), link add, and **Compact** (snapped renumber via
-`render(undefined, 0)`).
+Remove Points**) — a stable slot pool with `NaN` tombstones, links (a seed ring +
+nearest-neighbor links that fade with their points), and a live data panel
+(active vs. tombstoned slots). Demonstrates the full enter/exit matrix (each
+enter style mirroring an exit style) and **Compact** (snapped renumber + link
+remapping via `render(undefined, 0)`).
 
 ## Out of scope (by design)
 
@@ -156,14 +213,7 @@ enter style mirroring an exit style), link add, and **Compact** (snapped renumbe
   auto-compact — by design. Only the caller knows what indices are tied to (ids,
   links, selection), so the engine renumbering underneath them would break those.
   Callers reuse freed slots on add, or **Compact** when convenient.
-- **Link-level absence tracking** — no per-link absence state; a link is as absent as
-  its endpoints. (Follow-up: the line shader fades a link out with the exit ramp of
-  its endpoints and excludes it from link picking, so callers only drop removed
-  points' links when they compact.)
-- ~~**Position tracking** (`getTrackedPointPositionsMap`) — caller-owned, left
-  as-is.~~ Superseded by a follow-up: read-backs are honest about absence. An absent
-  point is omitted from the tracked map, and reads back as `NaN` from
-  `getPointPositions` / `getTrackedPointPositionsArray` (slots kept for index
-  alignment) — never as its frozen last on-screen coordinate. `fitView` therefore
-  ignores absent points. Drag is covered transitively (hover never returns an absent
-  point).
+- **Interrupting a fade mid-flight snaps it** — a data update arriving during a fade
+  re-derives the exit state, and the half-faded point completes instantly. This is
+  the codebase-wide interruption rule ("a new update supersedes the in-flight
+  animation"); smoothing it belongs to a future transition-system rework.

--- a/history/2026/2026-06-27-nan-point-removal.md
+++ b/history/2026/2026-06-27-nan-point-removal.md
@@ -102,8 +102,8 @@ snapped renumber shows zero movement.
 
 ```ts
 graph.setNextTransitionDuration(0) // snap the next update only
-graph.setPointPositions(compacted)
-graph.setPointColors(compacted)    // same update → also snaps
+graph.setPointPositions(compactedPositions) // [x0, y0, x1, y1, …]
+graph.setPointColors(compactedColors)        // [r0, g0, b0, a0, …], same update → also snaps
 ```
 
 A pending override wins even mid-animation (the `duration` getter returns it first),

--- a/history/2026/2026-06-27-nan-point-removal.md
+++ b/history/2026/2026-06-27-nan-point-removal.md
@@ -2,7 +2,7 @@
 
 # `NaN` positions for stable-identity point removal and addition
 
-**Commits:** 23ef59b, 8ed059f
+**Commits:** 9931bd8, 3985df6, e0a2a0b, f1768c1, 9575554
 
 ## Why
 
@@ -92,23 +92,27 @@ texture's `G` and skip absent points:
 Gravity/mouse/drag are per-point, so the integrator skip covers them. Works with the
 simulation on or off.
 
-## `setNextTransitionDuration(ms?)`
+## `render(simulationAlpha?, transitionDuration?)`
 
-New public method: a one-shot per-call override of `transitionDuration` for the next
-update only, then it auto-clears. `0` snaps. Mainly for **compaction** — after points
+`render` takes a second optional argument: the duration (ms) for any transition this
+render starts, for this call only. `0` snaps. Mainly for **compaction** — after points
 fade out you drop the tombstones and renumber, which must snap (an animated renumber
 would re-introduce the slide); since the surviving points keep their coordinates, a
 snapped renumber shows zero movement.
 
 ```ts
-graph.setNextTransitionDuration(0) // snap the next update only
 graph.setPointPositions(compactedPositions) // [x0, y0, x1, y1, …]
 graph.setPointColors(compactedColors)        // [r0, g0, b0, a0, …], same update → also snaps
+graph.render(undefined, 0)                    // snap this update only
 ```
 
-A pending override wins even mid-animation (the `duration` getter returns it first),
-so it reliably snaps an update issued while another transition is still playing; the
-running animation keeps its own length (`step()` reads `activeDuration` directly).
+`render` sets the duration on the transition (`setDurationOverride`) before the update
+pipeline runs and `start()` consumes it. It must be visible in that window because the
+pipeline (`Points.updatePositions`) reads it to choose animate vs. snap *before* `start()`
+runs. Because `render` sets it before every `start()`, it can't carry into another render —
+the leak the earlier approach was prone to. A transition already playing keeps its own
+length (`step()` reads `activeDuration` directly). An earlier iteration exposed a stateful
+`setNextTransitionDuration(ms?)` setter; it was folded into this argument before release.
 
 ## Picking, highlight & sampling exclude absent points
 
@@ -144,7 +148,7 @@ only means the exit default for an **absent** (NaN-position) one.
 Remove Points**) — a stable slot pool with `NaN` tombstones and a live data panel
 (active vs. tombstoned slots). Buttons demonstrate the full enter/exit matrix (each
 enter style mirroring an exit style), link add, and **Compact** (snapped renumber via
-`setNextTransitionDuration(0)`).
+`render(undefined, 0)`).
 
 ## Out of scope (by design)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cosmos.gl/graph",
-  "version": "3.2.0-beta.0",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cosmos.gl/graph",
-      "version": "3.2.0-beta.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@luma.gl/core": "~9.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cosmos.gl/graph",
-  "version": "3.1.0",
+  "version": "3.2.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cosmos.gl/graph",
-      "version": "3.1.0",
+      "version": "3.2.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@luma.gl/core": "~9.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmos.gl/graph",
-  "version": "3.1.0",
+  "version": "3.2.0-beta.0",
   "description": "GPU-based force graph layout and rendering",
   "jsdelivr": "dist/index.min.js",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmos.gl/graph",
-  "version": "3.2.0-beta.0",
+  "version": "3.2.0",
   "description": "GPU-based force graph layout and rendering",
   "jsdelivr": "dist/index.min.js",
   "main": "dist/index.js",

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -131,6 +131,14 @@ export function isNumber (value: number | undefined | null | typeof NaN): boolea
 }
 
 /**
+ * Reports whether the point at `index` is absent (removed): its position is `NaN`.
+ * A point is absent when either coordinate is `NaN`.
+ */
+export function isPointAbsent (pointPositions: Float32Array, index: number): boolean {
+  return Number.isNaN(pointPositions[index * 2] as number) || Number.isNaN(pointPositions[index * 2 + 1] as number)
+}
+
+/**
  * Sanitizes HTML content to prevent XSS attacks using DOMPurify
  *
  * This function is used internally to sanitize HTML content before setting innerHTML,

--- a/src/index.ts
+++ b/src/index.ts
@@ -456,26 +456,6 @@ export class Graph {
   }
 
   /**
-   * Overrides `config.transitionDuration` for the next transition cycle only.
-   *
-   * The next data update (`setPointPositions`, `setPointColors`, …) that triggers
-   * a transition uses this duration instead of the configured one, then the
-   * override clears automatically. Useful to apply a single update without
-   * animation, regardless of `config.transitionDuration`:
-   *
-   * ```ts
-   * graph.setNextTransitionDuration(0) // snap the next update
-   * graph.setPointPositions(positions)
-   * ```
-   *
-   * @param {number | undefined} duration - Duration in milliseconds for the next
-   *   cycle. `0` snaps with no animation; `undefined` falls back to config.
-   */
-  public setNextTransitionDuration (duration?: number): void {
-    this.transition.setNextDuration(duration)
-  }
-
-  /**
    * Sets the positions for the graph points.
    *
    * @param {Float32Array} pointPositions - A Float32Array representing the positions of points in the format [x1, y1, x2, y2, ..., xn, yn],
@@ -492,7 +472,7 @@ export class Graph {
    * fades to nothing; pass per-point `setPointSizes` / `setPointColors` to customize the exit look.
    * Absent points are excluded from the force layout, so this is safe with the simulation on or off.
    * cosmos.gl does not auto-compact the gaps — drop them yourself and snap the renumber with
-   * `setNextTransitionDuration(0)`.
+   * `render(undefined, 0)`.
    */
   public setPointPositions (pointPositions: Float32Array, dontRescale?: boolean | undefined): void {
     if (this._isDestroyed) return
@@ -827,11 +807,15 @@ export class Graph {
    *   - If 0: Sets alpha to 0, simulation stops after one frame (graph becomes static).
    *   - If positive: Sets alpha to that value.
    *   - If undefined: Keeps current alpha value.
+   * @param {number} [transitionDuration] - Duration in milliseconds for any transition started by
+   *   this render (from a preceding `setPointPositions` / `setPointColors` / … update), for this call
+   *   only. `0` snaps with no animation; `undefined` (default) uses `config.transitionDuration`.
+   *   To snap without changing the alpha, pass `render(undefined, 0)`.
    */
-  public render (simulationAlpha?: number): void {
+  public render (simulationAlpha?: number, transitionDuration?: number): void {
     if (this._isDestroyed) return
 
-    if (this.ensureDevice(() => this.render(simulationAlpha))) return
+    if (this.ensureDevice(() => this.render(simulationAlpha, transitionDuration))) return
     this.graph.update()
     const { fitViewOnInit, fitViewDelay, fitViewPadding, fitViewDuration, fitViewByPointsInRect, fitViewByPointIndices, initialZoomLevel } = this.config
     if (!this.graph.pointsNumber && !this.graph.linksNumber) {
@@ -863,6 +847,10 @@ export class Graph {
         } else this.fitView(fitViewDuration, fitViewPadding)
       }, fitViewDelay)
     }
+    // Set the override before the pipeline: `updatePositions()` (inside `this.update()` below) reads
+    // `transition.duration` to decide animate vs. snap, then `start()` consumes the override.
+    this.transition.setDurationOverride(transitionDuration)
+
     // Update graph and start frames
     this.update(simulationAlpha)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -483,16 +483,10 @@ export class Graph {
     this.isPointPositionsUpdateNeeded = true
     const currentPositionTexture = this.points?.currentPositionTexture
     if (currentPositionTexture && !currentPositionTexture.destroyed) {
+      // Only positions: the exit/enter fade of default-valued (NaN) channels is
+      // driven by the exit ramp in the draw shader, so no size/color transition is
+      // needed for a removal — and hover picking stays live during the fade.
       this.transition.queue(TransitionProperty.Positions)
-      // The exit/enter fade of a removed (NaN) or revived point is carried by size/color
-      // transitions, so queue them when a point's absence flipped even though the caller
-      // didn't call setPointSizes/Colors. Only then: an active size transition disables
-      // hover picking for its whole duration (see findHoveredItem), so a pure move must
-      // not activate one.
-      if (this.graph.hasPointAbsenceChanged()) {
-        this.transition.queue(TransitionProperty.PointSizes)
-        this.transition.queue(TransitionProperty.PointColors)
-      }
     }
     // Links related texture depends on point positions, so we need to update it
     this.isLinksUpdateNeeded = true
@@ -528,14 +522,25 @@ export class Graph {
   }
 
   /**
-   * Gets the current colors of the graph points.
+   * Gets the current colors of the graph points, as rendered: `NaN` channels are
+   * resolved to the config default (or the exit default for an absent point).
    *
-   * @returns {Float32Array} A Float32Array representing the colors of points in the format [r1, g1, b1, a1, r2, g2, b2, a2, ..., rn, gn, bn, an],
+   * @returns {Float32Array} A **new** Float32Array (a snapshot — safe to mutate, computed on
+   * each call) of point colors in the format [r1, g1, b1, a1, r2, g2, b2, a2, ..., rn, gn, bn, an],
    * where each color is in RGBA format. Returns an empty Float32Array if no point colors are set.
    */
   public getPointColors (): Float32Array {
     if (this._isDestroyed) return new Float32Array()
-    return this.graph.pointColors ?? new Float32Array()
+    if (this.graph.pointColors === undefined || this.graph.pointsNumber === undefined) return new Float32Array()
+    // Resolve on demand into a fresh array: internally colors stay raw (NaN =
+    // "use the default"), and the caller's input array is never modified.
+    const resolved = new Float32Array(this.graph.pointsNumber * 4)
+    for (let i = 0; i < this.graph.pointsNumber; i++) {
+      for (let channel = 0; channel < 4; channel++) {
+        resolved[i * 4 + channel] = this.graph.getResolvedPointColorChannel(i, channel)
+      }
+    }
+    return resolved
   }
 
   /**
@@ -617,14 +622,22 @@ export class Graph {
   }
 
   /**
-   * Gets the current sizes of the graph points.
+   * Gets the current sizes of the graph points, as rendered: `NaN` sizes are
+   * resolved to the config default (or the exit default for an absent point).
    *
-   * @returns {Float32Array} A Float32Array representing the sizes of points in the format [size1, size2, ..., sizen],
+   * @returns {Float32Array} A **new** Float32Array (a snapshot — safe to mutate, computed on
+   * each call) of point sizes in the format [size1, size2, ..., sizen],
    * where `n` is the index of the point. Returns an empty Float32Array if no point sizes are set.
    */
   public getPointSizes (): Float32Array {
     if (this._isDestroyed) return new Float32Array()
-    return this.graph.pointSizes ?? new Float32Array()
+    if (this.graph.pointSizes === undefined || this.graph.pointsNumber === undefined) return new Float32Array()
+    // Resolve on demand into a fresh array — see getPointColors.
+    const resolved = new Float32Array(this.graph.pointsNumber)
+    for (let i = 0; i < this.graph.pointsNumber; i++) {
+      resolved[i] = this.graph.getResolvedPointSize(i)
+    }
+    return resolved
   }
 
   /**
@@ -1209,10 +1222,11 @@ export class Graph {
    */
   public getPointRadiusByIndex (index: number): number | undefined {
     if (this._isDestroyed) return undefined
-    const shapeSize = this.graph.pointSizes?.[index]
+    if (this.graph.pointSizes === undefined && this.graph.pointImageSizes === undefined) return undefined
+    if (index < 0 || index >= (this.graph.pointsNumber ?? 0)) return undefined
+    const shapeSize = this.graph.getResolvedPointSize(index)
     const imageSize = this.graph.pointImageSizes?.[index]
-    if (shapeSize === undefined && imageSize === undefined) return undefined
-    return Math.max(shapeSize ?? 0, imageSize ?? 0)
+    return Math.max(shapeSize, imageSize ?? 0)
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -456,6 +456,26 @@ export class Graph {
   }
 
   /**
+   * Overrides `config.transitionDuration` for the next transition cycle only.
+   *
+   * The next data update (`setPointPositions`, `setPointColors`, …) that triggers
+   * a transition uses this duration instead of the configured one, then the
+   * override clears automatically. Useful to apply a single update without
+   * animation, regardless of `config.transitionDuration`:
+   *
+   * ```ts
+   * graph.setNextTransitionDuration(0) // snap the next update
+   * graph.setPointPositions(positions)
+   * ```
+   *
+   * @param {number | undefined} duration - Duration in milliseconds for the next
+   *   cycle. `0` snaps with no animation; `undefined` falls back to config.
+   */
+  public setNextTransitionDuration (duration?: number): void {
+    this.transition.setNextDuration(duration)
+  }
+
+  /**
    * Sets the positions for the graph points.
    *
    * @param {Float32Array} pointPositions - A Float32Array representing the positions of points in the format [x1, y1, x2, y2, ..., xn, yn],
@@ -466,6 +486,13 @@ export class Graph {
    *   - `false` or `undefined` (default): Use the behavior defined by `config.rescalePositions`.
    * @note If `transitionDuration > 0` and the simulation is running, the simulation is automatically
    * paused for the transition and remains paused afterwards. Call `unpause()` to resume it.
+   * @note A point whose position is `NaN` is treated as **absent**: it fades out in place while every
+   * other point keeps its index and on-screen position (no array compaction, no slide). Set a point to
+   * `NaN` to remove it, and back to a real position to add one — both animate. By default an absent point
+   * fades to nothing; pass per-point `setPointSizes` / `setPointColors` to customize the exit look.
+   * Absent points are excluded from the force layout, so this is safe with the simulation on or off.
+   * cosmos.gl does not auto-compact the gaps — drop them yourself and snap the renumber with
+   * `setNextTransitionDuration(0)`.
    */
   public setPointPositions (pointPositions: Float32Array, dontRescale?: boolean | undefined): void {
     if (this._isDestroyed) return
@@ -477,6 +504,11 @@ export class Graph {
     const currentPositionTexture = this.points?.currentPositionTexture
     if (currentPositionTexture && !currentPositionTexture.destroyed) {
       this.transition.queue(TransitionProperty.Positions)
+      // Also animate size/color so a point removed by a NaN position fades out to
+      // the exit default even when the caller doesn't call setPointSizes/Colors.
+      // No-op when those values are unchanged (source == target).
+      this.transition.queue(TransitionProperty.PointSizes)
+      this.transition.queue(TransitionProperty.PointColors)
     }
     // Links related texture depends on point positions, so we need to update it
     this.isLinksUpdateNeeded = true
@@ -498,6 +530,9 @@ export class Graph {
    * @param {Float32Array} pointColors - A Float32Array representing the colors of points in the format [r1, g1, b1, a1, r2, g2, b2, a2, ..., rn, gn, bn, an],
    * where each color is represented in RGBA format.
    * Example: `new Float32Array([1, 0, 0, 1, 0, 1, 0, 1])` sets the first point to red and the second point to green.
+   * @note A `NaN` channel resolves to the config default for a normal point, or to the exit default
+   * (transparent) for an **absent** point (one whose position is `NaN`) — letting you control how a
+   * removed point fades out (see `setPointPositions`).
   */
   public setPointColors (pointColors: Float32Array): void {
     if (this._isDestroyed) return
@@ -525,6 +560,9 @@ export class Graph {
    * @param {Float32Array} pointSizes - A Float32Array representing the sizes of points in the format [size1, size2, ..., sizen],
    * where `n` is the index of the point.
    * Example: `new Float32Array([10, 20, 30])` sets the first point to size 10, the second point to size 20, and the third point to size 30.
+   * @note A `NaN` size resolves to the config default for a normal point, or to the exit default (`0`)
+   * for an **absent** point (one whose position is `NaN`) — letting you control how a removed point
+   * fades out (see `setPointPositions`).
    */
   public setPointSizes (pointSizes: Float32Array): void {
     if (this._isDestroyed) return
@@ -836,7 +874,7 @@ export class Graph {
     // Color/size transitions are independent of physics and must not pause the simulation.
     if (this.transition.isPendingFor(TransitionProperty.Positions) &&
         this.store.isSimulationRunning &&
-        this.config.transitionDuration > 0 &&
+        this.transition.duration > 0 &&
         !this._isFirstRenderAfterInit) {
       this.store.isSimulationRunning = false
       this.config.onSimulationPause?.()
@@ -1952,7 +1990,7 @@ export class Graph {
       }
     }
 
-    this.points?.setTransitionProgress(this.transition.progress, shouldAnimatePointColors, shouldAnimatePointSizes)
+    this.points?.setTransitionProgress(this.transition.progress, shouldAnimatePointColors, shouldAnimatePointSizes, shouldInterpolatePositions)
     this.lines?.setTransitionProgress(this.transition.progress, shouldAnimateLinkColors, shouldAnimateLinkWidths)
 
     if (!this.dragInstance.isActive) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { Device, Framebuffer, luma } from '@luma.gl/core'
 import { webgl2Adapter } from '@luma.gl/webgl'
 
 import { applyConfig, createDefaultConfig, resetConfigToDefaults, GraphConfigInterface, type GraphConfig } from '@/graph/config'
-import { getRgbaColor, getMaxPointSize, readPixels, extractIndicesFromPixels, sanitizeHtml } from '@/graph/helper'
+import { getRgbaColor, getMaxPointSize, readPixels, extractIndicesFromPixels, sanitizeHtml, isPointAbsent } from '@/graph/helper'
 import { ForceCenter } from '@/graph/modules/ForceCenter'
 import { ForceCollision } from '@/graph/modules/ForceCollision'
 import { ForceGravity } from '@/graph/modules/ForceGravity'
@@ -892,12 +892,19 @@ export class Graph {
    * @param scale Scale value to zoom in or out (`3` by default).
    * @param canZoomOut Set to `false` to prevent zooming out from the point (`true` by default).
    * @param enableSimulation Whether to run the simulation during the zoom transition (`true` by default).
+   * @note An **absent** point (removed via a `NaN` position — see `setPointPositions`) is not a
+   * zoom target: the call is a no-op, same as hover and selection never landing on one.
    */
   public zoomToPointByIndex (index: number, duration = 700, scale = 3, canZoomOut = true, enableSimulation = true): void {
     if (this._isDestroyed) return
 
     if (this.ensureDevice(() => this.zoomToPointByIndex(index, duration, scale, canZoomOut, enableSimulation))) return
     if (!this.device || !this.points || !this.canvasD3Selection) return
+    // An absent (removed) point is not a zoom target. Checked on the input array: after
+    // an animated removal the GPU readback below still holds the point's frozen last
+    // real position, not NaN, so the readback can't tell absent from present.
+    const pointPositions = this.graph.pointPositions
+    if (!pointPositions || isPointAbsent(pointPositions, index)) return
     const { store: { screenSize } } = this
     const positionPixels = readPixels(this.device, this.points.currentPositionFbo as Framebuffer)
     if (index === undefined) return

--- a/src/index.ts
+++ b/src/index.ts
@@ -1983,7 +1983,7 @@ export class Graph {
     }
 
     this.points?.setTransitionProgress(this.transition.progress, shouldAnimatePointColors, shouldAnimatePointSizes, shouldInterpolatePositions)
-    this.lines?.setTransitionProgress(this.transition.progress, shouldAnimateLinkColors, shouldAnimateLinkWidths)
+    this.lines?.setTransitionProgress(this.transition.progress, shouldAnimateLinkColors, shouldAnimateLinkWidths, shouldInterpolatePositions)
 
     if (!this.dragInstance.isActive) {
       this.findHoveredItem()

--- a/src/index.ts
+++ b/src/index.ts
@@ -484,11 +484,15 @@ export class Graph {
     const currentPositionTexture = this.points?.currentPositionTexture
     if (currentPositionTexture && !currentPositionTexture.destroyed) {
       this.transition.queue(TransitionProperty.Positions)
-      // Also animate size/color so a point removed by a NaN position fades out to
-      // the exit default even when the caller doesn't call setPointSizes/Colors.
-      // No-op when those values are unchanged (source == target).
-      this.transition.queue(TransitionProperty.PointSizes)
-      this.transition.queue(TransitionProperty.PointColors)
+      // The exit/enter fade of a removed (NaN) or revived point is carried by size/color
+      // transitions, so queue them when a point's absence flipped even though the caller
+      // didn't call setPointSizes/Colors. Only then: an active size transition disables
+      // hover picking for its whole duration (see findHoveredItem), so a pure move must
+      // not activate one.
+      if (this.graph.hasPointAbsenceChanged()) {
+        this.transition.queue(TransitionProperty.PointSizes)
+        this.transition.queue(TransitionProperty.PointColors)
+      }
     }
     // Links related texture depends on point positions, so we need to update it
     this.isLinksUpdateNeeded = true

--- a/src/index.ts
+++ b/src/index.ts
@@ -466,7 +466,7 @@ export class Graph {
    *   - `false` or `undefined` (default): Use the behavior defined by `config.rescalePositions`.
    * @note If `transitionDuration > 0` and the simulation is running, the simulation is automatically
    * paused for the transition and remains paused afterwards. Call `unpause()` to resume it.
-   * @note A point whose position is `NaN` is treated as **absent**: it fades out in place while every
+   * @note A point whose position is `NaN` (either coordinate) is treated as **absent**: it fades out in place while every
    * other point keeps its index and on-screen position (no array compaction, no slide). Set a point to
    * `NaN` to remove it, and back to a real position to add one — both animate. By default an absent point
    * fades to nothing; pass per-point `setPointSizes` / `setPointColors` to customize the exit look.

--- a/src/index.ts
+++ b/src/index.ts
@@ -982,6 +982,9 @@ export class Graph {
   /**
    * Get current X and Y coordinates of the points.
    * @returns Array of point positions.
+   * @note An **absent** point (removed via a `NaN` position — see `setPointPositions`) reads back
+   * as `NaN`, mirroring the input — not as its last on-screen coordinate. This keeps removal
+   * detectable from the read-back and keeps absent points out of `fitView`.
    */
   public getPointPositions (): number[] {
     if (this._isDestroyed || !this.device || !this.points) return []
@@ -990,6 +993,14 @@ export class Graph {
     const pointPositionsPixels = readPixels(this.device, this.points.currentPositionFbo as Framebuffer)
     positions.length = this.graph.pointsNumber * 2
     for (let i = 0; i < this.graph.pointsNumber; i += 1) {
+      // An absent point reads back as NaN: the position texture keeps its frozen
+      // last coordinate (the fade renders from it), which must not read back as a
+      // live position.
+      if (this.graph.pointPositions && isPointAbsent(this.graph.pointPositions, i)) {
+        positions[i * 2] = NaN
+        positions[i * 2 + 1] = NaN
+        continue
+      }
       const posX = pointPositionsPixels[i * 4 + 0]
       const posY = pointPositionsPixels[i * 4 + 1]
       if (posX !== undefined && posY !== undefined) {
@@ -1221,6 +1232,10 @@ export class Graph {
    * Do not mutate the returned map - it may affect future calls.
    * @returns A ReadonlyMap where keys are point indices and values are their corresponding X and Y coordinates in the [number, number] format.
    * @see trackPointPositionsByIndices To set which points should be tracked
+   * @note An **absent** tracked point (removed via a `NaN` position — see `setPointPositions`) is
+   * omitted from the map — a missing key means "this point is gone". React to absence yourself
+   * (e.g. hide its label); the entry disappears as soon as the point is removed, even while its
+   * fade-out is still playing.
    */
   public getTrackedPointPositionsMap (): ReadonlyMap<number, [number, number]> {
     if (this._isDestroyed || !this.points) return new Map()
@@ -1232,6 +1247,8 @@ export class Graph {
    * @returns Array of point positions in the format [x1, y1, x2, y2, ..., xn, yn] for tracked points only.
    * The positions are ordered by the tracking indices (same order as provided to trackPointPositionsByIndices).
    * Returns an empty array if no points are being tracked.
+   * @note An **absent** tracked point (removed via a `NaN` position) reads back as `NaN` — the slot
+   * is kept so positions stay aligned with the tracked indices.
    */
   public getTrackedPointPositionsArray (): number[] {
     if (this._isDestroyed || !this.points) return []

--- a/src/modules/Clusters/calculate-centermass.vert
+++ b/src/modules/Clusters/calculate-centermass.vert
@@ -5,6 +5,7 @@ precision highp float;
 
 uniform sampler2D positionsTexture;
 uniform sampler2D clusterTexture;
+uniform sampler2D exitTexture;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform calculateCentermassUniforms {
@@ -24,6 +25,16 @@ in vec2 pointIndices;
 out vec4 rgba;
 
 void main() {
+  rgba = vec4(0.0);
+
+  // Absent points must not contribute to their cluster's centroid. (exit.G = absent)
+  vec4 exitStatus = texture(exitTexture, pointIndices / pointsTextureSize);
+  if (exitStatus.g > 0.5) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    gl_PointSize = 0.0;
+    return;
+  }
+
   vec4 pointPosition = texture(positionsTexture, pointIndices / pointsTextureSize);
   rgba = vec4(pointPosition.xy, 1.0, 0.0);
 

--- a/src/modules/Clusters/index.ts
+++ b/src/modules/Clusters/index.ts
@@ -362,6 +362,7 @@ export class Clusters extends CoreModule {
     if (!this.centermassFbo || this.centermassFbo.destroyed) return
     if (!this.clusterTexture || this.clusterTexture.destroyed) return
     if (!points.previousPositionTexture || points.previousPositionTexture.destroyed) return
+    if (!points.exitTexture || points.exitTexture.destroyed) return
 
     // Update vertex count dynamically (using same fallback logic as initialization)
     this.calculateCentermassCommand.setVertexCount(this.data.pointsNumber ?? 0)
@@ -378,6 +379,7 @@ export class Clusters extends CoreModule {
     this.calculateCentermassCommand.setBindings({
       clusterTexture: this.clusterTexture,
       positionsTexture: points.previousPositionTexture,
+      exitTexture: points.exitTexture,
     })
 
     // Create a RenderPass for the centermass framebuffer

--- a/src/modules/ForceCenter/calculate-centermass.vert
+++ b/src/modules/ForceCenter/calculate-centermass.vert
@@ -2,6 +2,7 @@
 precision highp float;
 
 uniform sampler2D positionsTexture;
+uniform sampler2D exitTexture;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform calculateCentermassUniforms {
@@ -18,6 +19,17 @@ in vec2 pointIndices;
 out vec4 rgba;
 
 void main() {
+  rgba = vec4(0.0);
+
+  // Absent points must not contribute to the centroid — a NaN position would
+  // poison the sum and break the force for every point. (exit.G = current absence)
+  vec4 exitStatus = texture(exitTexture, pointIndices / pointsTextureSize);
+  if (exitStatus.g > 0.5) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    gl_PointSize = 0.0;
+    return;
+  }
+
   vec4 pointPosition = texture(positionsTexture, pointIndices / pointsTextureSize);
   rgba = vec4(pointPosition.xy, 1.0, 0.0);
 

--- a/src/modules/ForceCenter/index.ts
+++ b/src/modules/ForceCenter/index.ts
@@ -170,6 +170,7 @@ export class ForceCenter extends CoreModule {
     if (!this.centermassFbo || !this.centermassTexture) return
     if (!points.previousPositionTexture || points.previousPositionTexture.destroyed) return
     if (!points.velocityFbo || points.velocityFbo.destroyed) return
+    if (!points.exitTexture || points.exitTexture.destroyed) return
 
     // Skip if sizes changed and create() wasn't called yet
     if (store.pointsTextureSize !== this.previousPointsTextureSize) return
@@ -191,6 +192,7 @@ export class ForceCenter extends CoreModule {
     // Update texture bindings dynamically
     this.calculateCentermassCommand.setBindings({
       positionsTexture: points.previousPositionTexture,
+      exitTexture: points.exitTexture,
     })
 
     this.calculateCentermassCommand.draw(centermassPass)

--- a/src/modules/ForceCollision/build-grid.vert
+++ b/src/modules/ForceCollision/build-grid.vert
@@ -3,6 +3,7 @@ precision highp float;
 
 uniform sampler2D positionsTexture;
 uniform sampler2D sizeTexture;
+uniform sampler2D exitTexture;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform buildGridUniforms {
@@ -28,6 +29,15 @@ in vec2 pointIndices;
 out vec4 cellData; // xy = position, z = size, w = count (1.0)
 
 void main() {
+  // Absent points must not enter the grid — a NaN position bins to a NaN cell and
+  // poisons the accumulated position/size sum for every point in that cell. (exit.g = absent)
+  vec4 exitStatus = texture(exitTexture, pointIndices / pointsTextureSize);
+  if (exitStatus.g > 0.5) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    gl_PointSize = 0.0;
+    return;
+  }
+
   vec4 pointPosition = texture(positionsTexture, pointIndices / pointsTextureSize);
   vec4 pointSize = texture(sizeTexture, pointIndices / pointsTextureSize);
 

--- a/src/modules/ForceCollision/index.ts
+++ b/src/modules/ForceCollision/index.ts
@@ -69,8 +69,10 @@ export class ForceCollision extends CoreModule {
     // large typed array as arguments can throw a RangeError on big graphs.
     const defaultSize = config.pointDefaultSize ?? defaultConfigValues.pointDefaultSize
     let maxSize = defaultSize
-    if (data.pointSizes) {
-      for (const size of data.pointSizes) maxSize = Math.max(maxSize, size)
+    if (data.pointSizes && data.pointsNumber !== undefined) {
+      // Resolve sizes: raw input arrays may hold NaN ("use the default"), which
+      // would poison Math.max.
+      for (let i = 0; i < data.pointsNumber; i++) maxSize = Math.max(maxSize, data.getResolvedPointSize(i))
     }
     const collisionRadius = config.simulationCollisionRadius ?? 0
     const collisionPadding = config.simulationCollisionPadding ?? 0
@@ -116,7 +118,7 @@ export class ForceCollision extends CoreModule {
     // Create size texture for collision radius calculation
     const sizeState = new Float32Array(store.pointsTextureSize * store.pointsTextureSize * 4)
     for (let i = 0; i < data.pointsNumber; i++) {
-      sizeState[i * 4] = data.pointSizes?.[i] ?? defaultSize
+      sizeState[i * 4] = data.getResolvedPointSize(i)
     }
 
     const recreateSizeTexture =

--- a/src/modules/ForceCollision/index.ts
+++ b/src/modules/ForceCollision/index.ts
@@ -266,6 +266,7 @@ export class ForceCollision extends CoreModule {
     if (!this.pointIndices) return
     if (data.pointsNumber === undefined) return
     if (!points.previousPositionTexture || points.previousPositionTexture.destroyed) return
+    if (!points.exitTexture || points.exitTexture.destroyed) return
     if (!points.velocityFbo || points.velocityFbo.destroyed) return
     if (!this.sizeTexture || this.sizeTexture.destroyed) return
     if (this.gridTargets.length !== GRID_OFFSETS.length) return
@@ -281,6 +282,7 @@ export class ForceCollision extends CoreModule {
     this.buildGridCommand.setBindings({
       positionsTexture: points.previousPositionTexture,
       sizeTexture: this.sizeTexture,
+      exitTexture: points.exitTexture,
     })
     for (const [i, gridOffset] of GRID_OFFSETS.entries()) {
       const target = this.gridTargets[i]

--- a/src/modules/ForceLink/force-spring.ts
+++ b/src/modules/ForceLink/force-spring.ts
@@ -3,6 +3,7 @@ export function forceFrag (maxLinks: number): string {
 precision highp float;
 
 uniform sampler2D positionsTexture;
+uniform sampler2D exitTexture;
 uniform sampler2D linkInfoTexture; // Texture storing first link indices and amount
 uniform sampler2D linkIndicesTexture;
 uniform sampler2D linkPropertiesTexture; // Texture storing link bias and strength
@@ -63,6 +64,13 @@ void main() {
         randomMinLinkDist *= linkDistance;
 
         iCount += 1.0;
+
+        // Skip a link to an absent point — its position would poison the spring
+        // force. (exit.G = current absence)
+        vec4 connectedExit = texture(exitTexture, (connectedPointIndex.rg + 0.5) / pointsTextureSize);
+        if (connectedExit.g > 0.5) {
+          continue;
+        }
 
         vec4 connectedPointPosition = texture(positionsTexture, (connectedPointIndex.rg + 0.5) / pointsTextureSize);
         float x = connectedPointPosition.x - (pointPosition.x + velocity.x);

--- a/src/modules/ForceLink/index.ts
+++ b/src/modules/ForceLink/index.ts
@@ -221,6 +221,7 @@ export class ForceLink extends CoreModule {
     if (!points) return
     if (!this.runCommand || !this.uniformStore) return
     if (!points.previousPositionTexture || points.previousPositionTexture.destroyed) return
+    if (!points.exitTexture || points.exitTexture.destroyed) return
     if (!this.linkFirstIndicesAndAmountTexture || !this.indicesTexture || !this.biasAndStrengthTexture || !this.randomDistanceTexture) return
     if (!points.velocityFbo || points.velocityFbo.destroyed) return
 
@@ -245,6 +246,7 @@ export class ForceLink extends CoreModule {
 
     this.runCommand.setBindings({
       positionsTexture: points.previousPositionTexture,
+      exitTexture: points.exitTexture,
       linkInfoTexture: this.linkFirstIndicesAndAmountTexture,
       linkIndicesTexture: this.indicesTexture,
       linkPropertiesTexture: this.biasAndStrengthTexture,

--- a/src/modules/ForceManyBody/calculate-level.vert
+++ b/src/modules/ForceManyBody/calculate-level.vert
@@ -2,6 +2,7 @@
 precision highp float;
 
 uniform sampler2D positionsTexture;
+uniform sampler2D exitTexture;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform calculateLevelsUniforms {
@@ -24,6 +25,17 @@ in vec2 pointIndices;
 out vec4 vColor;
 
 void main() {
+  vColor = vec4(0.0);
+
+  // Absent points must not enter the grid — a NaN position bins to a NaN cell and
+  // poisons the centermass that drives repulsion for every point. (exit.G = absent)
+  vec4 exitStatus = texture(exitTexture, pointIndices / pointsTextureSize);
+  if (exitStatus.g > 0.5) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    gl_PointSize = 0.0;
+    return;
+  }
+
   vec4 pointPosition = texture(positionsTexture, pointIndices / pointsTextureSize);
   vColor = vec4(pointPosition.rg, 1.0, 0.0);
 

--- a/src/modules/ForceManyBody/index.ts
+++ b/src/modules/ForceManyBody/index.ts
@@ -403,6 +403,7 @@ export class ForceManyBody extends CoreModule {
     if (!points) return
     if (!this.calculateLevelsCommand || !this.calculateLevelsUniformStore) return
     if (!points.previousPositionTexture || points.previousPositionTexture.destroyed) return
+    if (!points.exitTexture || points.exitTexture.destroyed) return
     if (!data.pointsNumber) return
     // Ensure pointIndices is set (Model might exist but attributes not set yet)
     if (!this.pointIndices) return
@@ -426,6 +427,7 @@ export class ForceManyBody extends CoreModule {
       // Update texture bindings dynamically
       this.calculateLevelsCommand.setBindings({
         positionsTexture: points.previousPositionTexture,
+        exitTexture: points.exitTexture,
       })
 
       const levelPass = device.beginRenderPass({

--- a/src/modules/GraphData/index.ts
+++ b/src/modules/GraphData/index.ts
@@ -101,6 +101,24 @@ export class GraphData {
   }
 
   /**
+   * Reports whether any point's absence (`NaN` position) differs between the applied
+   * positions and the pending input, over their shared length — i.e. whether the pending
+   * update removes (`real → NaN`) or revives (`NaN → real`) a point. Slots beyond the
+   * shared length don't count: a slot that enters already absent has nothing to fade,
+   * and a dropped slot no longer exists.
+   */
+  public hasPointAbsenceChanged (): boolean {
+    const previous = this.pointPositions
+    const next = this.inputPointPositions
+    if (!previous || !next || previous === next) return false
+    const sharedCount = Math.min(previous.length, next.length) / 2
+    for (let i = 0; i < sharedCount; i++) {
+      if (Number.isNaN(previous[i * 2] as number) !== Number.isNaN(next[i * 2] as number)) return true
+    }
+    return false
+  }
+
+  /**
    * Updates the point colors based on the input data or default config value.
    */
   public updatePointColor (): void {

--- a/src/modules/GraphData/index.ts
+++ b/src/modules/GraphData/index.ts
@@ -1,4 +1,4 @@
-import { getRgbaColor, isNumber } from '@/graph/helper'
+import { getRgbaColor, isNumber, isPointAbsent } from '@/graph/helper'
 import { type GraphConfigInterface } from '@/graph/config'
 import { defaultConfigValues } from '@/graph/variables'
 
@@ -113,7 +113,7 @@ export class GraphData {
     if (!previous || !next || previous === next) return false
     const sharedCount = Math.min(previous.length, next.length) / 2
     for (let i = 0; i < sharedCount; i++) {
-      if (Number.isNaN(previous[i * 2] as number) !== Number.isNaN(next[i * 2] as number)) return true
+      if (isPointAbsent(previous, i) !== isPointAbsent(next, i)) return true
     }
     return false
   }
@@ -135,7 +135,7 @@ export class GraphData {
         // No color array provided: present points get the config default; exiting
         // points (NaN position) get the exit default (0 → transparent) so they
         // still fade out without the caller providing colors.
-        if (Number.isNaN(this.pointPositions?.[i * 2] as number)) continue // leave 0
+        if (this.pointPositions && isPointAbsent(this.pointPositions, i)) continue // leave 0
         this.pointColors[i * 4] = defaultRgba[0]
         this.pointColors[i * 4 + 1] = defaultRgba[1]
         this.pointColors[i * 4 + 2] = defaultRgba[2]
@@ -146,7 +146,7 @@ export class GraphData {
       for (let i = 0; i < this.pointColors.length / 4; i++) {
         // A NaN channel resolves to the exit default (0) for an exiting point
         // (NaN position), otherwise to the config default.
-        const exiting = Number.isNaN(this.pointPositions?.[i * 2] as number)
+        const exiting = this.pointPositions !== undefined && isPointAbsent(this.pointPositions, i)
         for (let c = 0; c < 4; c++) {
           if (!isNumber(this.pointColors[i * 4 + c])) {
             this.pointColors[i * 4 + c] = exiting ? EXIT_DEFAULT_COLOR_CHANNEL : (defaultRgba[c] as number)
@@ -172,7 +172,7 @@ export class GraphData {
       // No size array provided: exiting points (NaN position) get the exit default
       // so they still fade out without the caller providing sizes.
       for (let i = 0; i < this.pointsNumber; i++) {
-        if (Number.isNaN(this.pointPositions?.[i * 2] as number)) this.pointSizes[i] = EXIT_DEFAULT_SIZE
+        if (this.pointPositions && isPointAbsent(this.pointPositions, i)) this.pointSizes[i] = EXIT_DEFAULT_SIZE
       }
     } else {
       this.pointSizes = this.inputPointSizes
@@ -180,7 +180,7 @@ export class GraphData {
         if (!isNumber(this.pointSizes[i])) {
           // NaN resolves to the exit default for an exiting point (NaN
           // position), otherwise to the config default.
-          const exiting = Number.isNaN(this.pointPositions?.[i * 2] as number)
+          const exiting = this.pointPositions !== undefined && isPointAbsent(this.pointPositions, i)
           this.pointSizes[i] = exiting ? EXIT_DEFAULT_SIZE : defaultSize
         }
       }

--- a/src/modules/GraphData/index.ts
+++ b/src/modules/GraphData/index.ts
@@ -2,6 +2,11 @@ import { getRgbaColor, isNumber } from '@/graph/helper'
 import { type GraphConfigInterface } from '@/graph/config'
 import { defaultConfigValues } from '@/graph/variables'
 
+// Defaults a `NaN` size/color resolves to for an *exiting* point (NaN position):
+// fade to nothing. (A live point falls back to the config defaults instead.)
+const EXIT_DEFAULT_SIZE = 0
+const EXIT_DEFAULT_COLOR_CHANNEL = 0
+
 export enum PointShape {
   Circle = 0,
   Square = 1,
@@ -109,6 +114,10 @@ export class GraphData {
     if (this.inputPointColors === undefined || this.inputPointColors.length / 4 !== this.pointsNumber) {
       this.pointColors = new Float32Array(this.pointsNumber * 4)
       for (let i = 0; i < this.pointColors.length / 4; i++) {
+        // No color array provided: present points get the config default; exiting
+        // points (NaN position) get the exit default (0 → transparent) so they
+        // still fade out without the caller providing colors.
+        if (Number.isNaN(this.pointPositions?.[i * 2] as number)) continue // leave 0
         this.pointColors[i * 4] = defaultRgba[0]
         this.pointColors[i * 4 + 1] = defaultRgba[1]
         this.pointColors[i * 4 + 2] = defaultRgba[2]
@@ -117,10 +126,14 @@ export class GraphData {
     } else {
       this.pointColors = this.inputPointColors
       for (let i = 0; i < this.pointColors.length / 4; i++) {
-        if (!isNumber(this.pointColors[i * 4])) this.pointColors[i * 4] = defaultRgba[0]
-        if (!isNumber(this.pointColors[i * 4 + 1])) this.pointColors[i * 4 + 1] = defaultRgba[1]
-        if (!isNumber(this.pointColors[i * 4 + 2])) this.pointColors[i * 4 + 2] = defaultRgba[2]
-        if (!isNumber(this.pointColors[i * 4 + 3])) this.pointColors[i * 4 + 3] = defaultRgba[3]
+        // A NaN channel resolves to the exit default (0) for an exiting point
+        // (NaN position), otherwise to the config default.
+        const exiting = Number.isNaN(this.pointPositions?.[i * 2] as number)
+        for (let c = 0; c < 4; c++) {
+          if (!isNumber(this.pointColors[i * 4 + c])) {
+            this.pointColors[i * 4 + c] = exiting ? EXIT_DEFAULT_COLOR_CHANNEL : defaultRgba[c]
+          }
+        }
       }
     }
   }
@@ -138,11 +151,19 @@ export class GraphData {
     const defaultSize = this._config.pointDefaultSize
     if (this.inputPointSizes === undefined || this.inputPointSizes.length !== this.pointsNumber) {
       this.pointSizes = new Float32Array(this.pointsNumber).fill(defaultSize)
+      // No size array provided: exiting points (NaN position) get the exit default
+      // so they still fade out without the caller providing sizes.
+      for (let i = 0; i < this.pointsNumber; i++) {
+        if (Number.isNaN(this.pointPositions?.[i * 2] as number)) this.pointSizes[i] = EXIT_DEFAULT_SIZE
+      }
     } else {
       this.pointSizes = this.inputPointSizes
       for (let i = 0; i < this.pointSizes.length; i++) {
         if (!isNumber(this.pointSizes[i])) {
-          this.pointSizes[i] = defaultSize
+          // NaN resolves to the exit default for an exiting point (NaN
+          // position), otherwise to the config default.
+          const exiting = Number.isNaN(this.pointPositions?.[i * 2] as number)
+          this.pointSizes[i] = exiting ? EXIT_DEFAULT_SIZE : defaultSize
         }
       }
     }

--- a/src/modules/GraphData/index.ts
+++ b/src/modules/GraphData/index.ts
@@ -90,9 +90,11 @@ export class GraphData {
 
   /**
    * Parsed `pointDefaultColor`, cached between updates (`updatePointColor`
-   * invalidates it, so config changes are picked up).
+   * invalidates it, so config changes are picked up). Public so the draw pass can
+   * feed it to the shader's `pointDefaultColor` uniform without re-parsing the
+   * config color string every frame.
    */
-  private get defaultRgba (): [number, number, number, number] {
+  public get defaultRgba (): [number, number, number, number] {
     this._defaultRgba ??= getRgbaColor(this._config.pointDefaultColor)
     return this._defaultRgba
   }

--- a/src/modules/GraphData/index.ts
+++ b/src/modules/GraphData/index.ts
@@ -131,7 +131,7 @@ export class GraphData {
         const exiting = Number.isNaN(this.pointPositions?.[i * 2] as number)
         for (let c = 0; c < 4; c++) {
           if (!isNumber(this.pointColors[i * 4 + c])) {
-            this.pointColors[i * 4 + c] = exiting ? EXIT_DEFAULT_COLOR_CHANNEL : defaultRgba[c]
+            this.pointColors[i * 4 + c] = exiting ? EXIT_DEFAULT_COLOR_CHANNEL : (defaultRgba[c] as number)
           }
         }
       }

--- a/src/modules/GraphData/index.ts
+++ b/src/modules/GraphData/index.ts
@@ -1,11 +1,6 @@
 import { getRgbaColor, isNumber, isPointAbsent } from '@/graph/helper'
 import { type GraphConfigInterface } from '@/graph/config'
-import { defaultConfigValues } from '@/graph/variables'
-
-// Defaults a `NaN` size/color resolves to for an *exiting* point (NaN position):
-// fade to nothing. (A live point falls back to the config defaults instead.)
-const EXIT_DEFAULT_SIZE = 0
-const EXIT_DEFAULT_COLOR_CHANNEL = 0
+import { defaultConfigValues, EXIT_DEFAULT_SIZE, EXIT_DEFAULT_COLOR_CHANNEL } from '@/graph/variables'
 
 export enum PointShape {
   Circle = 0,
@@ -78,6 +73,8 @@ export class GraphData {
   public inDegree: number[] | undefined
   public outDegree: number[] | undefined
   private _config: GraphConfigInterface
+  /** Lazily parsed `pointDefaultColor` — see the `defaultRgba` getter. */
+  private _defaultRgba: [number, number, number, number] | undefined
 
   public constructor (config: GraphConfigInterface) {
     this._config = config
@@ -91,6 +88,15 @@ export class GraphData {
     return this.links && this.links.length / 2
   }
 
+  /**
+   * Parsed `pointDefaultColor`, cached between updates (`updatePointColor`
+   * invalidates it, so config changes are picked up).
+   */
+  private get defaultRgba (): [number, number, number, number] {
+    this._defaultRgba ??= getRgbaColor(this._config.pointDefaultColor)
+    return this._defaultRgba
+  }
+
   public updatePoints (): void {
     // Don't sync the same positions twice — it breaks animations when points are added or removed.
     if (this.pointPositions === this.inputPointPositions) return
@@ -98,24 +104,6 @@ export class GraphData {
     this.sourcePointsNumber = this.pointPositions ? this.pointPositions.length / 2 : 0
     this.pointPositions = this.inputPointPositions
     this.targetPointsNumber = this.pointPositions ? this.pointPositions.length / 2 : 0
-  }
-
-  /**
-   * Reports whether any point's absence (`NaN` position) differs between the applied
-   * positions and the pending input, over their shared length — i.e. whether the pending
-   * update removes (`real → NaN`) or revives (`NaN → real`) a point. Slots beyond the
-   * shared length don't count: a slot that enters already absent has nothing to fade,
-   * and a dropped slot no longer exists.
-   */
-  public hasPointAbsenceChanged (): boolean {
-    const previous = this.pointPositions
-    const next = this.inputPointPositions
-    if (!previous || !next || previous === next) return false
-    const sharedCount = Math.min(previous.length, next.length) / 2
-    for (let i = 0; i < sharedCount; i++) {
-      if (isPointAbsent(previous, i) !== isPointAbsent(next, i)) return true
-    }
-    return false
   }
 
   /**
@@ -127,33 +115,30 @@ export class GraphData {
       return
     }
 
-    // Sets point colors to default values from config if the input is missing or does not match input points number.
-    const defaultRgba = getRgbaColor(this._config.pointDefaultColor)
+    // NaN channels are not resolved here — the caller's array is used as-is (never
+    // edited), and resolution happens at read time: the draw shader resolves NaN
+    // against the point's absence and the config default, and CPU consumers go
+    // through `getResolvedPointColorChannel`/`getResolvedPointSize`. A missing or
+    // mismatched input becomes an all-NaN array: "resolve every channel".
+    this._defaultRgba = undefined // config may have changed — re-parse lazily
     if (this.inputPointColors === undefined || this.inputPointColors.length / 4 !== this.pointsNumber) {
-      this.pointColors = new Float32Array(this.pointsNumber * 4)
-      for (let i = 0; i < this.pointColors.length / 4; i++) {
-        // No color array provided: present points get the config default; exiting
-        // points (NaN position) get the exit default (0 → transparent) so they
-        // still fade out without the caller providing colors.
-        if (this.pointPositions && isPointAbsent(this.pointPositions, i)) continue // leave 0
-        this.pointColors[i * 4] = defaultRgba[0]
-        this.pointColors[i * 4 + 1] = defaultRgba[1]
-        this.pointColors[i * 4 + 2] = defaultRgba[2]
-        this.pointColors[i * 4 + 3] = defaultRgba[3]
-      }
+      this.pointColors = new Float32Array(this.pointsNumber * 4).fill(NaN)
     } else {
       this.pointColors = this.inputPointColors
-      for (let i = 0; i < this.pointColors.length / 4; i++) {
-        // A NaN channel resolves to the exit default (0) for an exiting point
-        // (NaN position), otherwise to the config default.
-        const exiting = this.pointPositions !== undefined && isPointAbsent(this.pointPositions, i)
-        for (let c = 0; c < 4; c++) {
-          if (!isNumber(this.pointColors[i * 4 + c])) {
-            this.pointColors[i * 4 + c] = exiting ? EXIT_DEFAULT_COLOR_CHANNEL : (defaultRgba[c] as number)
-          }
-        }
-      }
     }
+  }
+
+  /**
+   * Resolves one color channel of a point the way the draw shader does: a `NaN`
+   * channel means the exit default (transparent) for an **absent** point, the
+   * config default otherwise. The CPU mirror of the shader rule, for consumers
+   * that read colors outside the GPU.
+   */
+  public getResolvedPointColorChannel (index: number, channel: number): number {
+    const raw = this.pointColors?.[index * 4 + channel]
+    if (isNumber(raw)) return raw as number
+    if (this.pointPositions && isPointAbsent(this.pointPositions, index)) return EXIT_DEFAULT_COLOR_CHANNEL
+    return this.defaultRgba[channel] as number
   }
 
   /**
@@ -165,26 +150,26 @@ export class GraphData {
       return
     }
 
-    // Sets point sizes to default values from config if the input is missing or does not match input points number.
-    const defaultSize = this._config.pointDefaultSize
+    // Like updatePointColor: no resolution here — read-time resolution in the draw
+    // shader / `getResolvedPointSize`, and the caller's array is never edited.
     if (this.inputPointSizes === undefined || this.inputPointSizes.length !== this.pointsNumber) {
-      this.pointSizes = new Float32Array(this.pointsNumber).fill(defaultSize)
-      // No size array provided: exiting points (NaN position) get the exit default
-      // so they still fade out without the caller providing sizes.
-      for (let i = 0; i < this.pointsNumber; i++) {
-        if (this.pointPositions && isPointAbsent(this.pointPositions, i)) this.pointSizes[i] = EXIT_DEFAULT_SIZE
-      }
+      this.pointSizes = new Float32Array(this.pointsNumber).fill(NaN)
     } else {
       this.pointSizes = this.inputPointSizes
-      for (let i = 0; i < this.pointSizes.length; i++) {
-        if (!isNumber(this.pointSizes[i])) {
-          // NaN resolves to the exit default for an exiting point (NaN
-          // position), otherwise to the config default.
-          const exiting = this.pointPositions !== undefined && isPointAbsent(this.pointPositions, i)
-          this.pointSizes[i] = exiting ? EXIT_DEFAULT_SIZE : defaultSize
-        }
-      }
     }
+  }
+
+  /**
+   * Resolves a point's size the way the draw shader does: `NaN` means the exit
+   * default (`0`) for an **absent** point, the config default otherwise. The CPU
+   * mirror of the shader rule, for consumers that read sizes outside the GPU
+   * (collision, hover ring, read-back).
+   */
+  public getResolvedPointSize (index: number): number {
+    const raw = this.pointSizes?.[index]
+    if (isNumber(raw)) return raw as number
+    if (this.pointPositions && isPointAbsent(this.pointPositions, index)) return EXIT_DEFAULT_SIZE
+    return this._config.pointDefaultSize
   }
 
   /**
@@ -253,14 +238,16 @@ export class GraphData {
     }
 
     // Sets point image sizes to point sizes if the input is missing or does not match input points number.
-    const defaultSize = this._config.pointDefaultSize
+    // Point sizes are read through the resolver: the raw array may hold NaN
+    // ("use the default"), which must not reach the image-size buffer.
     if (this.inputPointImageSizes === undefined || this.inputPointImageSizes.length !== this.pointsNumber) {
-      this.pointImageSizes = this.pointSizes ? new Float32Array(this.pointSizes) : new Float32Array(this.pointsNumber).fill(defaultSize)
+      this.pointImageSizes = new Float32Array(this.pointsNumber)
+      for (let i = 0; i < this.pointsNumber; i++) this.pointImageSizes[i] = this.getResolvedPointSize(i)
     } else {
       this.pointImageSizes = new Float32Array(this.inputPointImageSizes)
       for (let i = 0; i < this.pointImageSizes.length; i++) {
         if (!isNumber(this.pointImageSizes[i])) {
-          this.pointImageSizes[i] = this.pointSizes?.[i] ?? defaultSize
+          this.pointImageSizes[i] = this.getResolvedPointSize(i)
         }
       }
     }

--- a/src/modules/Lines/draw-curve-line.vert
+++ b/src/modules/Lines/draw-curve-line.vert
@@ -13,6 +13,7 @@ in float linkIndices;
 
 uniform sampler2D positionsTexture;
 uniform sampler2D linkStatus;
+uniform sampler2D exitTexture;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform drawLineUniforms {
@@ -42,6 +43,7 @@ layout(std140) uniform drawLineUniforms {
   float transitionProgress;
   float animateColors;
   float animateWidths;
+  float animatePositions;
 } drawLine;
 
 #define transformationMatrix drawLine.transformationMatrix
@@ -70,6 +72,7 @@ layout(std140) uniform drawLineUniforms {
 #define transitionProgress drawLine.transitionProgress
 #define animateColors drawLine.animateColors
 #define animateWidths drawLine.animateWidths
+#define animatePositions drawLine.animatePositions
 #else
 uniform mat3 transformationMatrix;
 uniform float pointsTextureSize;
@@ -98,6 +101,7 @@ uniform float focusedLinkWidthIncrease;
 uniform float transitionProgress;
 uniform float animateColors;
 uniform float animateWidths;
+uniform float animatePositions;
 #endif
 
 out vec4 rgbaColor;
@@ -156,8 +160,33 @@ void main() {
   vec2 b = pointPositionB.xy;
 
   // Skip links touching an absent (NaN position) point — interpolating from a NaN
-  // endpoint would produce garbage geometry. Collapse the link off-screen.
+  // endpoint would produce garbage geometry. Collapse the link off-screen. This only
+  // catches snap removals: an animated removal freezes the endpoint at its last real
+  // position, so absence must be read from the exit texture below.
   if (isnan(a.x) || isnan(a.y) || isnan(b.x) || isnan(b.y)) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    return;
+  }
+
+  // Exit status of both endpoints (R = previous absence, G = current absence). A link
+  // is only as present as its endpoints.
+  vec4 exitStatusA = texture(exitTexture, pointTexturePosA);
+  vec4 exitStatusB = texture(exitTexture, pointTexturePosB);
+
+  // Picking must not report a link to a removed point even mid-fade — same rule as
+  // point picking, which excludes on current absence.
+  if (renderMode > 0.0 && (exitStatusA.g > 0.5 || exitStatusB.g > 0.5)) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    return;
+  }
+
+  // Visible pass: fade the link with the same animated exit ramp the point fade uses
+  // (blend R→G during a position transition, settled G otherwise), so a removed
+  // point's links fade out in sync with it instead of dangling at full opacity.
+  float exitA = animatePositions > 0.0 ? mix(exitStatusA.r, exitStatusA.g, transitionProgress) : exitStatusA.g;
+  float exitB = animatePositions > 0.0 ? mix(exitStatusB.r, exitStatusB.g, transitionProgress) : exitStatusB.g;
+  float exitPresence = (1.0 - exitA) * (1.0 - exitB);
+  if (exitPresence <= 0.0) {
     gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
     return;
   }
@@ -239,6 +268,8 @@ void main() {
   vec3 rgbColor = lineColor.rgb;
   // Adjust opacity based on link distance
   float opacity = lineColor.a * linkOpacity * max(linkVisibilityMinTransparency, map(linkDistPx, linkVisibilityDistanceRange.g, linkVisibilityDistanceRange.r, 0.0, 1.0));
+  // Fade with the exit ramp of the endpoints (1 = both fully present).
+  opacity *= exitPresence;
 
   // Apply greyed-out opacity from link status texture
   if (isLinkHighlightingActive > 0.0 && linkStatusTextureSize > 0.0) {

--- a/src/modules/Lines/draw-curve-line.vert
+++ b/src/modules/Lines/draw-curve-line.vert
@@ -154,7 +154,14 @@ void main() {
   vec4 pointPositionB = texture(positionsTexture, pointTexturePosB);
   vec2 a = pointPositionA.xy;
   vec2 b = pointPositionB.xy;
-  
+
+  // Skip links touching an absent (NaN position) point — interpolating from a NaN
+  // endpoint would produce garbage geometry. Collapse the link off-screen.
+  if (isnan(a.x) || isnan(a.y) || isnan(b.x) || isnan(b.y)) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    return;
+  }
+
   // Calculate direction vector and its perpendicular
   vec2 xBasis = b - a;
   vec2 yBasis = normalize(vec2(-xBasis.y, xBasis.x));

--- a/src/modules/Lines/fill-sampled-links.vert
+++ b/src/modules/Lines/fill-sampled-links.vert
@@ -8,6 +8,7 @@ in vec2 pointB;
 in float linkIndices;
 
 uniform sampler2D positionsTexture;
+uniform sampler2D exitTexture;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform fillSampledLinksUniforms {
@@ -40,6 +41,14 @@ uniform mat3 transformationMatrix;
 out vec4 rgba;
 
 void main() {
+  // Skip a link touching an absent (faded-out) point. exit.G = current absence.
+  if (texture(exitTexture, (pointA + 0.5) / pointsTextureSize).g > 0.5 ||
+      texture(exitTexture, (pointB + 0.5) / pointsTextureSize).g > 0.5) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    gl_PointSize = 0.0;
+    return;
+  }
+
   vec4 posA = texture(positionsTexture, (pointA + 0.5) / pointsTextureSize);
   vec4 posB = texture(positionsTexture, (pointB + 0.5) / pointsTextureSize);
   vec2 a = posA.rg;

--- a/src/modules/Lines/index.ts
+++ b/src/modules/Lines/index.ts
@@ -99,6 +99,7 @@ export class Lines extends CoreModule {
       transitionProgress: number;
       animateColors: number;
       animateWidths: number;
+      animatePositions: number;
     };
     drawLineFragmentUniforms: {
       renderMode: number;

--- a/src/modules/Lines/index.ts
+++ b/src/modules/Lines/index.ts
@@ -733,6 +733,7 @@ export class Lines extends CoreModule {
     if (!this.sampledLinksFbo || this.sampledLinksFbo.destroyed) return positions
     const points = this.points
     if (!points?.currentPositionTexture || points.currentPositionTexture.destroyed) return positions
+    if (!points.exitTexture || points.exitTexture.destroyed) return positions
 
     if (this.fillSampledLinksFboCommand && this.fillSampledLinksUniformStore && this.sampledLinksFbo) {
       this.fillSampledLinksFboCommand.setVertexCount(this.data.linksNumber ?? 0)
@@ -749,6 +750,7 @@ export class Lines extends CoreModule {
       })
       this.fillSampledLinksFboCommand.setBindings({
         positionsTexture: points.currentPositionTexture,
+        exitTexture: points.exitTexture,
       })
 
       const fillPass = this.device.beginRenderPass({
@@ -780,6 +782,7 @@ export class Lines extends CoreModule {
     if (!this.sampledLinksFbo || this.sampledLinksFbo.destroyed) return { indices, positions, angles }
     const points = this.points
     if (!points?.currentPositionTexture || points.currentPositionTexture.destroyed) return { indices, positions, angles }
+    if (!points.exitTexture || points.exitTexture.destroyed) return { indices, positions, angles }
 
     if (this.fillSampledLinksFboCommand && this.fillSampledLinksUniformStore && this.sampledLinksFbo) {
       this.fillSampledLinksFboCommand.setVertexCount(this.data.linksNumber ?? 0)
@@ -796,6 +799,7 @@ export class Lines extends CoreModule {
       })
       this.fillSampledLinksFboCommand.setBindings({
         positionsTexture: points.currentPositionTexture,
+        exitTexture: points.exitTexture,
       })
 
       const fillPass = this.device.beginRenderPass({

--- a/src/modules/Lines/index.ts
+++ b/src/modules/Lines/index.ts
@@ -57,6 +57,7 @@ export class Lines extends CoreModule {
   private transitionProgress = 1
   private shouldAnimateLinkColors = false
   private shouldAnimateLinkWidths = false
+  private shouldAnimatePositions = false
   private fillSampledLinksUniformStore: UniformStore<{
     fillSampledLinksUniforms: {
       pointsTextureSize: number;
@@ -187,6 +188,7 @@ export class Lines extends CoreModule {
           transitionProgress: 'f32',
           animateColors: 'f32',
           animateWidths: 'f32',
+          animatePositions: 'f32',
         },
         defaultUniforms: {
           transformationMatrix: store.transformationMatrix4x4,
@@ -215,6 +217,7 @@ export class Lines extends CoreModule {
           transitionProgress: 1,
           animateColors: 0,
           animateWidths: 0,
+          animatePositions: 0,
         },
       },
       drawLineFragmentUniforms: {
@@ -333,6 +336,8 @@ export class Lines extends CoreModule {
     const { config, points, store } = this
     if (!points) return
     if (!points.currentPositionTexture || points.currentPositionTexture.destroyed) return
+    if (!points.exitTexture) points.updateExit()
+    if (!points.exitTexture || points.exitTexture.destroyed) return
     if (!this.pointABuffer || !this.pointBBuffer) this.updatePointsBuffer()
     if (!this.targetColorBuffer) this.updateColor()
     if (!this.targetWidthBuffer) this.updateWidth()
@@ -373,6 +378,7 @@ export class Lines extends CoreModule {
         transitionProgress: this.transitionProgress,
         animateColors: this.shouldAnimateLinkColors ? 1 : 0,
         animateWidths: this.shouldAnimateLinkWidths ? 1 : 0,
+        animatePositions: this.shouldAnimatePositions ? 1 : 0,
       },
       drawLineFragmentUniforms: {
         renderMode: 0.0, // Normal rendering
@@ -383,6 +389,7 @@ export class Lines extends CoreModule {
     this.drawCurveCommand.setBindings({
       positionsTexture: points.currentPositionTexture,
       linkStatus: this.linkStatusTexture,
+      exitTexture: points.exitTexture,
     })
 
     // Update instance count
@@ -830,6 +837,8 @@ export class Lines extends CoreModule {
     const { config, points, store } = this
     if (!points) return
     if (!points.currentPositionTexture || points.currentPositionTexture.destroyed) return
+    if (!points.exitTexture) points.updateExit()
+    if (!points.exitTexture || points.exitTexture.destroyed) return
     if (!this.data.linksNumber || !this.store.isLinkHoveringEnabled) return
     if (!this.linkIndexFbo || !this.drawLineUniformStore || !this.linkStatusTexture) return
     if (!this.linkIndexTexture || this.linkIndexTexture.destroyed) return
@@ -869,6 +878,7 @@ export class Lines extends CoreModule {
         transitionProgress: this.transitionProgress,
         animateColors: this.shouldAnimateLinkColors ? 1 : 0,
         animateWidths: this.shouldAnimateLinkWidths ? 1 : 0,
+        animatePositions: this.shouldAnimatePositions ? 1 : 0,
       },
       drawLineFragmentUniforms: {
         renderMode: 1.0, // Index rendering for picking
@@ -879,6 +889,7 @@ export class Lines extends CoreModule {
     this.drawCurvePickingCommand.setBindings({
       positionsTexture: points.currentPositionTexture,
       linkStatus: this.linkStatusTexture,
+      exitTexture: points.exitTexture,
     })
 
     // Update instance count
@@ -914,10 +925,11 @@ export class Lines extends CoreModule {
     }
   }
 
-  public setTransitionProgress (progress: number, animateColors = false, animateWidths = false): void {
+  public setTransitionProgress (progress: number, animateColors = false, animateWidths = false, animatePositions = false): void {
     this.transitionProgress = progress
     this.shouldAnimateLinkColors = animateColors
     this.shouldAnimateLinkWidths = animateWidths
+    this.shouldAnimatePositions = animatePositions
   }
 
   /**

--- a/src/modules/Points/draw-highlighted.vert
+++ b/src/modules/Points/draw-highlighted.vert
@@ -7,6 +7,7 @@ in vec2 vertexCoord;
 
 uniform sampler2D positionsTexture;
 uniform sampler2D pointStatus;
+uniform sampler2D exitTexture;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform drawHighlightedUniforms {
@@ -83,6 +84,13 @@ void main () {
   vertexPosition = vertexCoord;
 
   vec2 textureCoordinates = vec2(mod(pointIndex, pointsTextureSize), floor(pointIndex / pointsTextureSize)) + 0.5;
+
+  // Don't draw a highlight/outline for an absent (faded-out) point. exit.G = absent.
+  if (texture(exitTexture, textureCoordinates / pointsTextureSize).g > 0.5) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    return;
+  }
+
   vec4 pointPosition = texture(positionsTexture, textureCoordinates / pointsTextureSize);
 
   rgbColor = color.rgb;

--- a/src/modules/Points/draw-points.vert
+++ b/src/modules/Points/draw-points.vert
@@ -39,6 +39,8 @@ layout(std140) uniform drawVertexUniforms {
   float animateColors;
   float animateSizes;
   float animatePositions;
+  vec4 pointDefaultColor;
+  float pointDefaultSize;
 } drawVertex;
 
 #define ratio drawVertex.ratio
@@ -61,6 +63,8 @@ layout(std140) uniform drawVertexUniforms {
 #define animateColors drawVertex.animateColors
 #define animateSizes drawVertex.animateSizes
 #define animatePositions drawVertex.animatePositions
+#define pointDefaultColor drawVertex.pointDefaultColor
+#define pointDefaultSize drawVertex.pointDefaultSize
 #else
 uniform float ratio;
 uniform mat3 transformationMatrix;
@@ -82,6 +86,8 @@ uniform float transitionProgress;
 uniform float animateColors;
 uniform float animateSizes;
 uniform float animatePositions;
+uniform vec4 pointDefaultColor;
+uniform float pointDefaultSize;
 #endif
 
 out float pointShape;
@@ -106,6 +112,23 @@ float calculatePointSize(float size) {
 }
 
 const float outlineRingScale = 1.3;
+
+// Read-time resolution of NaN channels — input arrays are used verbatim and never
+// edited, so "use the default" stays encoded as NaN all the way to the GPU. A NaN
+// resolves to the config default blended toward the exit default along the animated
+// exit ramp (0 = present, 1 = gone), so the enter/exit fade of default-valued
+// channels drives itself — no size/color transition needed for a removal. Explicit
+// (real) values pass through. EXIT_DEFAULT_* are #defines injected from variables.ts,
+// shared with the CPU resolvers (GraphData.getResolvedPoint*).
+float resolveSize(float size, float exitRamp) {
+  if (!isnan(size)) return size;
+  return mix(pointDefaultSize, EXIT_DEFAULT_SIZE, exitRamp);
+}
+
+vec4 resolveColor(vec4 color, float exitRamp) {
+  vec4 defaultColor = mix(pointDefaultColor, vec4(EXIT_DEFAULT_COLOR_CHANNEL), exitRamp);
+  return mix(color, defaultColor, isnan(color));
+}
 
 void main() {
   // Read point status texture: R = greyout, G = outlined
@@ -162,12 +185,15 @@ void main() {
   #endif
   gl_Position = vec4(finalPosition.rg, 0, 1);
 
+  // Resolve NaN channels against the animated exit ramp before mixing — default
+  // sizes/colors of an entering or leaving point fade with the ramp regardless of
+  // whether a size/color transition is active.
   float pointSize = animateSizes > 0.0
-    ? mix(sourceSize, targetSize, transitionProgress)
-    : targetSize;
+    ? mix(resolveSize(sourceSize, exit), resolveSize(targetSize, exit), transitionProgress)
+    : resolveSize(targetSize, exit);
   vec4 pointColor = animateColors > 0.0
-    ? mix(sourceColor, targetColor, transitionProgress)
-    : targetColor;
+    ? mix(resolveColor(sourceColor, exit), resolveColor(targetColor, exit), transitionProgress)
+    : resolveColor(targetColor, exit);
 
 
   // Calculate sizes for shape and image

--- a/src/modules/Points/draw-points.vert
+++ b/src/modules/Points/draw-points.vert
@@ -14,6 +14,7 @@ in float imageSize;
 
 uniform sampler2D positionsTexture;
 uniform sampler2D pointStatus;
+uniform sampler2D exitTexture;
 uniform sampler2D imageAtlasCoords;
 
 #ifdef USE_UNIFORM_BUFFERS
@@ -37,6 +38,7 @@ layout(std140) uniform drawVertexUniforms {
   float transitionProgress;
   float animateColors;
   float animateSizes;
+  float animatePositions;
 } drawVertex;
 
 #define ratio drawVertex.ratio
@@ -58,6 +60,7 @@ layout(std140) uniform drawVertexUniforms {
 #define transitionProgress drawVertex.transitionProgress
 #define animateColors drawVertex.animateColors
 #define animateSizes drawVertex.animateSizes
+#define animatePositions drawVertex.animatePositions
 #else
 uniform float ratio;
 uniform mat3 transformationMatrix;
@@ -78,6 +81,7 @@ uniform float imageAtlasCoordsTextureSize;
 uniform float transitionProgress;
 uniform float animateColors;
 uniform float animateSizes;
+uniform float animatePositions;
 #endif
 
 out float pointShape;
@@ -122,6 +126,22 @@ void main() {
     return;
   }
 
+  // Exit texture: R = previous absence, G = current absence (1 = absent). During a
+  // position transition, blend R→G to animate the enter/exit; otherwise use G (the
+  // settled current absence) so an unrelated color/size transition can't replay the
+  // ramp. The caller drives the visual fade via setPointSizes/setPointColors; here
+  // we only remove the point once it is fully gone.
+  vec4 exitStatus = texture(exitTexture, (pointIndices + 0.5) / pointsTextureSize);
+  float exit = animatePositions > 0.0
+    ? mix(exitStatus.r, exitStatus.g, transitionProgress)
+    : exitStatus.g;
+  if (exit >= 1.0) {
+    // Fully gone — skip. Also avoids using a NaN position on the snapped path.
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    gl_PointSize = 0.0;
+    return;
+  }
+
   // Position
   vec4 pointPosition = texture(positionsTexture, (pointIndices + 0.5) / pointsTextureSize);
   vec2 point = pointPosition.rg;
@@ -148,6 +168,7 @@ void main() {
   vec4 pointColor = animateColors > 0.0
     ? mix(sourceColor, targetColor, transitionProgress)
     : targetColor;
+
 
   // Calculate sizes for shape and image
   float shapeSizeValue = calculatePointSize(pointSize * sizeScale);

--- a/src/modules/Points/fill-sampled-points.vert
+++ b/src/modules/Points/fill-sampled-points.vert
@@ -6,6 +6,7 @@ precision highp float;
 in vec2 pointIndices;
 
 uniform sampler2D positionsTexture;
+uniform sampler2D exitTexture;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform fillSampledPointsUniforms {
@@ -29,6 +30,14 @@ uniform mat3 transformationMatrix;
 out vec4 rgba;
 
 void main() {
+  // Keep absent (faded-out) points out of the sample. exit.G = current absence.
+  if (texture(exitTexture, (pointIndices + 0.5) / pointsTextureSize).g > 0.5) {
+    rgba = vec4(0.0);
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    gl_PointSize = 0.0;
+    return;
+  }
+
   vec4 pointPosition = texture(positionsTexture, (pointIndices + 0.5) / pointsTextureSize);
   vec2 p = 2.0 * pointPosition.rg / spaceSize - 1.0;
   p *= spaceSize / screenSize;

--- a/src/modules/Points/find-hovered-point.vert
+++ b/src/modules/Points/find-hovered-point.vert
@@ -9,6 +9,7 @@ in float imageSize;
 
 uniform sampler2D positionsTexture;
 uniform sampler2D pointStatus;
+uniform sampler2D exitTexture;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform findHoveredPointUniforms {
@@ -69,6 +70,17 @@ float euclideanDistance (float x1, float x2, float y1, float y2) {
 }
 
 void main() {
+  // Skip absent (faded-out) points so hover never lands on a removed one. Their
+  // size/position may still look hittable mid-fade (only alpha faded), so the exit
+  // status is the reliable signal. exit.G = current absence.
+  vec4 exitStatus = texture(exitTexture, (pointIndices + 0.5) / pointsTextureSize);
+  if (exitStatus.g > 0.5) {
+    rgba = vec4(0.0);
+    gl_Position = vec4(0.5, 0.5, 0.0, 1.0);
+    gl_PointSize = 1.0;
+    return;
+  }
+
   vec4 greyoutStatus = texture(pointStatus, (pointIndices + 0.5) / pointsTextureSize);
   float isHighlighted = (greyoutStatus.r == 0.0) ? 1.0 : 0.0;
 

--- a/src/modules/Points/find-hovered-point.vert
+++ b/src/modules/Points/find-hovered-point.vert
@@ -24,6 +24,7 @@ layout(std140) uniform findHoveredPointUniforms {
   float maxPointSize;
   float skipHighlighted;
   float skipGreyed;
+  float pointDefaultSize;
 } findHoveredPoint;
 
 #define pointsTextureSize findHoveredPoint.pointsTextureSize
@@ -37,6 +38,7 @@ layout(std140) uniform findHoveredPointUniforms {
 #define maxPointSize findHoveredPoint.maxPointSize
 #define skipHighlighted findHoveredPoint.skipHighlighted
 #define skipGreyed findHoveredPoint.skipGreyed
+#define pointDefaultSize findHoveredPoint.pointDefaultSize
 #else
 uniform float pointsTextureSize;
 uniform float sizeScale;
@@ -49,6 +51,7 @@ uniform float scalePointsOnZoom;
 uniform float maxPointSize;
 uniform float skipHighlighted;
 uniform float skipGreyed;
+uniform float pointDefaultSize;
 #endif
 
 out vec4 rgba;
@@ -110,17 +113,21 @@ void main() {
   vec3 finalPosition = transformationMatrix * vec3(normalizedPosition, 1);
   #endif
 
-  float shapeSizeValue = calculatePointSize(size * sizeScale);
+  // Resolve a NaN size at read time. The absent-point guard above already returned,
+  // so a NaN here means "use the config default".
+  float resolvedSize = isnan(size) ? pointDefaultSize : size;
+
+  float shapeSizeValue = calculatePointSize(resolvedSize * sizeScale);
   float imageSizeValue = calculatePointSize(imageSize * sizeScale);
   float pointRadius = 0.5 * max(shapeSizeValue, imageSizeValue);
   vec2 pointScreenPosition = (finalPosition.xy + 1.0) * screenSize / 2.0;
-  
+
   rgba = vec4(0.0);
   gl_Position = vec4(0.5, 0.5, 0.0, 1.0);
-  
+
   if (euclideanDistance(pointScreenPosition.x, mousePosition.x, pointScreenPosition.y, mousePosition.y) < pointRadius / ratio) {
     float index = pointIndices.g * pointsTextureSize + pointIndices.r;
-    rgba = vec4(index, max(size, imageSize), pointPosition.xy);
+    rgba = vec4(index, max(resolvedSize, imageSize), pointPosition.xy);
     gl_Position = vec4(-0.5, -0.5, 0.0, 1.0);
   }
 

--- a/src/modules/Points/find-points-in-polygon.frag
+++ b/src/modules/Points/find-points-in-polygon.frag
@@ -5,6 +5,7 @@ precision highp float;
 
 uniform sampler2D positionsTexture;
 uniform sampler2D polygonPathTexture; // Texture containing polygon path points
+uniform sampler2D exitTexture;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform findPointsInPolygonUniforms {
@@ -66,6 +67,12 @@ bool pointInPolygon(vec2 point, sampler2D pathTexture, int pathLength) {
 }
 
 void main() {
+  // Skip absent (faded-out) points — never select a removed point. exit.G = absent.
+  if (texture(exitTexture, textureCoords).g > 0.5) {
+    fragColor = vec4(0.0);
+    return;
+  }
+
   vec4 pointPosition = texture(positionsTexture, textureCoords);
   vec2 p = 2.0 * pointPosition.rg / spaceSize - 1.0;
   p *= spaceSize / screenSize;

--- a/src/modules/Points/find-points-in-rect.frag
+++ b/src/modules/Points/find-points-in-rect.frag
@@ -5,6 +5,7 @@ precision highp float;
 
 uniform sampler2D positionsTexture;
 uniform sampler2D pointSize;
+uniform sampler2D exitTexture;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform findPointsInRectUniforms {
@@ -61,6 +62,12 @@ float pointSizeF(float size) {
 }
 
 void main() {
+  // Skip absent (faded-out) points — never select a removed point. exit.G = absent.
+  if (texture(exitTexture, textureCoords).g > 0.5) {
+    fragColor = vec4(0.0);
+    return;
+  }
+
   vec4 pointPosition = texture(positionsTexture, textureCoords);
   vec2 p = 2.0 * pointPosition.rg / spaceSize - 1.0;
   p *= spaceSize / screenSize;

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -676,9 +676,9 @@ export class Points extends CoreModule {
       defines: {
         USE_UNIFORM_BUFFERS: true,
         // Exit defaults shared with the CPU resolvers (variables.ts) — formatted as
-        // GLSL float literals.
-        EXIT_DEFAULT_SIZE: EXIT_DEFAULT_SIZE.toFixed(1),
-        EXIT_DEFAULT_COLOR_CHANNEL: EXIT_DEFAULT_COLOR_CHANNEL.toFixed(1),
+        // exact GLSL float literals (`.toFixed` would round non-integer values).
+        EXIT_DEFAULT_SIZE: Number.isInteger(EXIT_DEFAULT_SIZE) ? EXIT_DEFAULT_SIZE.toFixed(1) : String(EXIT_DEFAULT_SIZE),
+        EXIT_DEFAULT_COLOR_CHANNEL: Number.isInteger(EXIT_DEFAULT_COLOR_CHANNEL) ? EXIT_DEFAULT_COLOR_CHANNEL.toFixed(1) : String(EXIT_DEFAULT_COLOR_CHANNEL),
       },
       bindings: {
         // Create uniform buffer binding
@@ -1262,7 +1262,9 @@ export class Points extends CoreModule {
 
     const initialState = new Float32Array(pointsTextureSize * pointsTextureSize * 4)
     for (let i = 0; i < data.pointsNumber; i++) {
-      const shapeSize = sizeData[i] as number
+      // Resolve the raw size: a NaN ("use the default") would poison Math.max and
+      // give the point a NaN radius in the rect-selection shader.
+      const shapeSize = data.getResolvedPointSize(i)
       const imageSize = data.pointImageSizes?.[i] ?? shapeSize
       initialState[i * 4] = Math.max(shapeSize, imageSize)
     }
@@ -1562,7 +1564,8 @@ export class Points extends CoreModule {
       animateColors: this.shouldAnimatePointColors ? 1 : 0,
       animateSizes: this.shouldAnimatePointSizes ? 1 : 0,
       animatePositions: this.shouldAnimatePointPositions ? 1 : 0,
-      pointDefaultColor: ensureVec4(getRgbaColor(config.pointDefaultColor), [0, 0, 0, 1]),
+      // Cached parse — draw() runs per frame, so no color-string parsing here.
+      pointDefaultColor: ensureVec4(data.defaultRgba, [0, 0, 0, 1]),
       pointDefaultSize: config.pointDefaultSize,
     }
 

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -1166,9 +1166,9 @@ export class Points extends CoreModule {
     // Build R = previous absence, G = current absence.
     const state = new Float32Array(pointsTextureSize * pointsTextureSize * 4)
     for (let i = 0; i < count; i++) {
-      const current = nextPrevious[i]
+      const current = nextPrevious[i] as number
       // New slots (no history) start with previous = current, so no spurious fade.
-      const previous = i < (prev?.length ?? 0) ? (prev as Float32Array)[i] : current
+      const previous = i < (prev?.length ?? 0) ? (prev as Float32Array)[i] as number : current
       state[i * 4] = previous
       state[i * 4 + 1] = current
     }

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -1147,7 +1147,7 @@ export class Points extends CoreModule {
     const nextPrevious = new Float32Array(count)
     let anyAbsentNow = false
     for (let i = 0; i < count; i++) {
-      const current = data.pointPositions && Number.isNaN(data.pointPositions[i * 2]) ? 1 : 0
+      const current = data.pointPositions && isPointAbsent(data.pointPositions, i) ? 1 : 0
       nextPrevious[i] = current
       if (current) anyAbsentNow = true
     }
@@ -2730,7 +2730,7 @@ export class Points extends CoreModule {
       const y = points[i + 1] as number
       // Skip absent (NaN) points: `Math.min/max(…, NaN)` is `NaN`, which would
       // poison the extent and rescale every point to NaN (vanishing the graph).
-      if (Number.isNaN(x) || Number.isNaN(y)) continue
+      if (isPointAbsent(points, i / 2)) continue
       minX = Math.min(minX, x)
       maxX = Math.max(maxX, x)
       minY = Math.min(minY, y)
@@ -2753,9 +2753,8 @@ export class Points extends CoreModule {
       this.scaleX = (x: number): number => x - minX + center
       this.scaleY = (y: number): number => y - minY + center
       for (let i = 0; i < pointsNumber; i++) {
-        const x = points[i * 2] as number
-        if (Number.isNaN(x)) continue // leave absent points NaN
-        this.data.pointPositions[i * 2] = this.scaleX(x)
+        if (isPointAbsent(points, i)) continue // leave absent points NaN
+        this.data.pointPositions[i * 2] = this.scaleX(points[i * 2] as number)
         this.data.pointPositions[i * 2 + 1] = this.scaleY(points[i * 2 + 1] as number)
       }
       return
@@ -2790,9 +2789,8 @@ export class Points extends CoreModule {
 
     // Apply scaling to point positions
     for (let i = 0; i < pointsNumber; i++) {
-      const x = points[i * 2] as number
-      if (Number.isNaN(x)) continue // leave absent points NaN
-      this.data.pointPositions[i * 2] = this.scaleX(x)
+      if (isPointAbsent(points, i)) continue // leave absent points NaN
+      this.data.pointPositions[i * 2] = this.scaleX(points[i * 2] as number)
       this.data.pointPositions[i * 2 + 1] = this.scaleY(points[i * 2 + 1] as number)
     }
   }

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -69,6 +69,12 @@ export class Points extends CoreModule {
   public previousPositionTexture: Texture | undefined
   public velocityTexture: Texture | undefined
   public pointStatusTexture: Texture | undefined
+  // Exit status, derived from NaN positions (R = previous absence, G = current
+  // absence; 1 = absent). The single source of truth for "is this point leaving /
+  // gone": draw blends R→G by transition progress for the fade gone-guard, while
+  // the integrator and force modules read G to exclude absent points from physics.
+  // Public so the force modules can sample it.
+  public exitTexture: Texture | undefined
   /**
    * Start of a position transition — the "from" positions blended by
    * `interpolatePosition()`. Populated by `updatePositions()` when an animated
@@ -97,6 +103,12 @@ export class Points extends CoreModule {
   private sourceSizeBuffer: Buffer | undefined
   private targetSizeBuffer: Buffer | undefined
   private previousSizeData: Float32Array | undefined
+  // Previous-frame absence per point (1 = absent), kept so the next `updateExit`
+  // can fill the exit texture's R (previous) channel.
+  private previousExitData: Float32Array | undefined
+  // True when the exit texture is entirely zero (no point absent now or last
+  // frame). Lets `updateExit` skip the alloc + upload on the common no-NaN path.
+  private isExitTextureAllZero = false
   private shapeBuffer: Buffer | undefined
   private imageIndicesBuffer: Buffer | undefined
   private imageSizesBuffer: Buffer | undefined
@@ -152,6 +164,7 @@ export class Points extends CoreModule {
   private transitionProgress = 1
   private shouldAnimatePointColors = false
   private shouldAnimatePointSizes = false
+  private shouldAnimatePointPositions = false
 
   // Uniform stores for scalar uniforms
   private updatePositionUniformStore: UniformStore<{
@@ -311,7 +324,7 @@ export class Points extends CoreModule {
     const sameCount = sourceCount === targetCount
     const shouldAnimate =
       this.transition?.isPendingFor(TransitionProperty.Positions) === true &&
-      this.config.transitionDuration > 0 &&
+      (this.transition?.duration ?? this.config.transitionDuration) > 0 &&
       !!this.currentPositionTexture
 
     const targetState = buildPositionTextureData(data.pointPositions, pointsTextureSize, targetCount)
@@ -471,6 +484,7 @@ export class Points extends CoreModule {
 
     this.updatePointStatus()
     this.updatePinnedStatus()
+    this.updateExit()
     this.updateSampledPointsGrid()
 
     // Animated path: render loop refreshes after each `interpolatePosition()`.
@@ -560,6 +574,7 @@ export class Points extends CoreModule {
           transitionProgress: 'f32',
           animateColors: 'f32',
           animateSizes: 'f32',
+          animatePositions: 'f32',
         },
         defaultUniforms: {
           // Order MUST match uniformTypes and shader declaration
@@ -590,6 +605,7 @@ export class Points extends CoreModule {
           transitionProgress: 1,
           animateColors: 0,
           animateSizes: 0,
+          animatePositions: 0,
         },
       },
       drawFragmentUniforms: {
@@ -1116,6 +1132,69 @@ export class Points extends CoreModule {
     }
   }
 
+  // Builds the exit texture from point positions: R = previous absence, G = current
+  // absence (1 = NaN position). One signal for both pipelines: the draw shader
+  // blends R→G by transition progress (the fade gone-guard), and the integrator
+  // and force shaders read G to skip absent points so a NaN never poisons physics.
+  public updateExit (): void {
+    const { device, store: { pointsTextureSize }, data } = this
+    if (!pointsTextureSize) return
+
+    const count = data.pointsNumber ?? 0
+    const prev = this.previousExitData
+
+    // Cheap scan: current absence per point, and whether anything is absent now.
+    const nextPrevious = new Float32Array(count)
+    let anyAbsentNow = false
+    for (let i = 0; i < count; i++) {
+      const current = data.pointPositions && Number.isNaN(data.pointPositions[i * 2]) ? 1 : 0
+      nextPrevious[i] = current
+      if (current) anyAbsentNow = true
+    }
+    let anyAbsentBefore = false
+    if (prev) for (let i = 0; i < prev.length; i++) if (prev[i]) { anyAbsentBefore = true; break }
+
+    const sameSize = !!this.exitTexture && this.exitTexture.width === pointsTextureSize && this.exitTexture.height === pointsTextureSize
+
+    // Fast path for the common (no-NaN) case: the texture would be all-zero (no R
+    // or G set) and the existing one already is — skip the big alloc + GPU upload.
+    if (!anyAbsentNow && !anyAbsentBefore && sameSize && this.isExitTextureAllZero) {
+      this.previousExitData = nextPrevious
+      return
+    }
+
+    // Build R = previous absence, G = current absence.
+    const state = new Float32Array(pointsTextureSize * pointsTextureSize * 4)
+    for (let i = 0; i < count; i++) {
+      const current = nextPrevious[i]
+      // New slots (no history) start with previous = current, so no spurious fade.
+      const previous = i < (prev?.length ?? 0) ? (prev as Float32Array)[i] : current
+      state[i * 4] = previous
+      state[i * 4 + 1] = current
+    }
+    this.previousExitData = nextPrevious
+
+    if (!this.exitTexture || !sameSize) {
+      if (this.exitTexture && !this.exitTexture.destroyed) {
+        this.exitTexture.destroy()
+      }
+      this.exitTexture = device.createTexture({
+        width: pointsTextureSize,
+        height: pointsTextureSize,
+        format: 'rgba32float',
+      })
+    }
+    this.exitTexture.copyImageData({
+      data: state,
+      bytesPerRow: getBytesPerRow('rgba32float', pointsTextureSize),
+      mipLevel: 0,
+      x: 0,
+      y: 0,
+    })
+    // The texture is all-zero iff no point is (or was) absent.
+    this.isExitTextureAllZero = !anyAbsentNow && !anyAbsentBefore
+  }
+
   public updateSize (): void {
     const { device, store: { pointsTextureSize }, data } = this
     if (!pointsTextureSize || data.pointsNumber === undefined) return
@@ -1383,16 +1462,18 @@ export class Points extends CoreModule {
     renderPass.end()
   }
 
-  public setTransitionProgress (progress: number, animateColors = false, animateSizes = false): void {
+  public setTransitionProgress (progress: number, animateColors = false, animateSizes = false, animatePositions = false): void {
     this.transitionProgress = progress
     this.shouldAnimatePointColors = animateColors
     this.shouldAnimatePointSizes = animateSizes
+    this.shouldAnimatePointPositions = animatePositions
   }
 
   public draw (renderPass: RenderPass): void {
     const { data, config, store } = this
     if (!this.targetColorBuffer) this.updateColor()
     if (!this.targetSizeBuffer) this.updateSize()
+    if (!this.exitTexture) this.updateExit()
     if (!this.shapeBuffer) this.updateShape()
     if (!this.imageIndicesBuffer) this.updateImageIndices()
     if (!this.imageSizesBuffer) this.updateImageSizes()
@@ -1400,6 +1481,7 @@ export class Points extends CoreModule {
     if (!this.drawCommand || !this.drawUniformStore) return
     if (!this.currentPositionTexture || this.currentPositionTexture.destroyed) return
     if (!this.pointStatusTexture || this.pointStatusTexture.destroyed) return
+    if (!this.exitTexture || this.exitTexture.destroyed) return
     if (!this.imageAtlasTexture || !this.imageAtlasCoordsTexture) {
       this.createAtlas()
       if (!this.imageAtlasTexture || !this.imageAtlasCoordsTexture) return
@@ -1439,6 +1521,7 @@ export class Points extends CoreModule {
       transitionProgress: this.transitionProgress,
       animateColors: this.shouldAnimatePointColors ? 1 : 0,
       animateSizes: this.shouldAnimatePointSizes ? 1 : 0,
+      animatePositions: this.shouldAnimatePointPositions ? 1 : 0,
     }
 
     const baseFragmentUniforms = {
@@ -1468,6 +1551,7 @@ export class Points extends CoreModule {
       this.drawCommand.setBindings({
         positionsTexture: this.currentPositionTexture,
         pointStatus: this.pointStatusTexture,
+        exitTexture: this.exitTexture,
         imageAtlasTexture: this.imageAtlasTexture,
         imageAtlasCoords: this.imageAtlasCoordsTexture,
       })
@@ -1487,6 +1571,7 @@ export class Points extends CoreModule {
       this.drawCommand.setBindings({
         positionsTexture: this.currentPositionTexture,
         pointStatus: this.pointStatusTexture,
+        exitTexture: this.exitTexture,
         imageAtlasTexture: this.imageAtlasTexture,
         imageAtlasCoords: this.imageAtlasCoordsTexture,
       })
@@ -1506,6 +1591,7 @@ export class Points extends CoreModule {
       this.drawCommand.setBindings({
         positionsTexture: this.currentPositionTexture,
         pointStatus: this.pointStatusTexture,
+        exitTexture: this.exitTexture,
         imageAtlasTexture: this.imageAtlasTexture,
         imageAtlasCoords: this.imageAtlasCoordsTexture,
       })
@@ -1544,6 +1630,7 @@ export class Points extends CoreModule {
       this.drawHighlightedCommand.setBindings({
         positionsTexture: this.currentPositionTexture,
         pointStatus: this.pointStatusTexture,
+        exitTexture: this.exitTexture,
       })
       this.drawHighlightedCommand.draw(renderPass)
     }
@@ -1578,6 +1665,7 @@ export class Points extends CoreModule {
       this.drawHighlightedCommand.setBindings({
         positionsTexture: this.currentPositionTexture,
         pointStatus: this.pointStatusTexture,
+        exitTexture: this.exitTexture,
       })
       this.drawHighlightedCommand.draw(renderPass)
     }
@@ -1588,6 +1676,7 @@ export class Points extends CoreModule {
     if (!this.previousPositionTexture || this.previousPositionTexture.destroyed) return
     if (!this.velocityTexture || this.velocityTexture.destroyed) return
     if (!this.pinnedStatusTexture || this.pinnedStatusTexture.destroyed) return
+    if (!this.exitTexture || this.exitTexture.destroyed) return
 
     this.updatePositionUniformStore.setUniforms({
       updatePositionUniforms: {
@@ -1601,6 +1690,7 @@ export class Points extends CoreModule {
       positionsTexture: this.previousPositionTexture,
       velocity: this.velocityTexture,
       pinnedStatusTexture: this.pinnedStatusTexture,
+      exitTexture: this.exitTexture,
     })
 
     const renderPass = this.device.beginRenderPass({
@@ -1649,6 +1739,8 @@ export class Points extends CoreModule {
     if (!this.findPointsInRectCommand || !this.findPointsInRectUniformStore || !this.searchFbo || this.searchFbo.destroyed) return false
     if (!this.currentPositionTexture || this.currentPositionTexture.destroyed) return false
     if (!this.sizeTexture || this.sizeTexture.destroyed) return false
+    if (!this.exitTexture) this.updateExit()
+    if (!this.exitTexture || this.exitTexture.destroyed) return false
 
     this.findPointsInRectUniformStore.setUniforms({
       findPointsInRectUniforms: {
@@ -1668,6 +1760,7 @@ export class Points extends CoreModule {
     this.findPointsInRectCommand.setBindings({
       positionsTexture: this.currentPositionTexture,
       pointSize: this.sizeTexture,
+      exitTexture: this.exitTexture,
     })
 
     const renderPass = this.device.beginRenderPass({
@@ -1682,6 +1775,8 @@ export class Points extends CoreModule {
     if (!this.findPointsInPolygonCommand || !this.findPointsInPolygonUniformStore || !this.searchFbo || this.searchFbo.destroyed) return false
     if (!this.currentPositionTexture || this.currentPositionTexture.destroyed) return false
     if (!this.polygonPathTexture || this.polygonPathTexture.destroyed) return false
+    if (!this.exitTexture) this.updateExit()
+    if (!this.exitTexture || this.exitTexture.destroyed) return false
 
     this.findPointsInPolygonUniformStore.setUniforms({
       findPointsInPolygonUniforms: {
@@ -1696,6 +1791,7 @@ export class Points extends CoreModule {
     this.findPointsInPolygonCommand.setBindings({
       positionsTexture: this.currentPositionTexture,
       polygonPathTexture: this.polygonPathTexture,
+      exitTexture: this.exitTexture,
     })
 
     const renderPass = this.device.beginRenderPass({
@@ -1765,6 +1861,8 @@ export class Points extends CoreModule {
     if (!this.currentPositionTexture || this.currentPositionTexture.destroyed) return
     if (!this.pointStatusTexture) this.updatePointStatus()
     if (!this.pointStatusTexture || this.pointStatusTexture.destroyed) return
+    if (!this.exitTexture) this.updateExit()
+    if (!this.exitTexture || this.exitTexture.destroyed) return
 
     this.findHoveredPointCommand.setVertexCount(this.data.pointsNumber ?? 0)
 
@@ -1789,6 +1887,7 @@ export class Points extends CoreModule {
     const bindings = {
       positionsTexture: this.currentPositionTexture,
       pointStatus: this.pointStatusTexture,
+      exitTexture: this.exitTexture,
     }
 
     const renderPass = this.device.beginRenderPass({
@@ -1944,6 +2043,8 @@ export class Points extends CoreModule {
     // Fill sampled points FBO
     if (this.fillSampledPointsFboCommand && this.fillSampledPointsUniformStore && this.sampledPointsFbo) {
       if (!this.currentPositionTexture || this.currentPositionTexture.destroyed) return positions
+      if (!this.exitTexture) this.updateExit()
+      if (!this.exitTexture || this.exitTexture.destroyed) return positions
       // Update vertex count dynamically
       this.fillSampledPointsFboCommand.setVertexCount(this.data.pointsNumber ?? 0)
 
@@ -1959,6 +2060,7 @@ export class Points extends CoreModule {
       // Update texture bindings dynamically
       this.fillSampledPointsFboCommand.setBindings({
         positionsTexture: this.currentPositionTexture,
+        exitTexture: this.exitTexture,
       })
 
       const fillPass = this.device.beginRenderPass({
@@ -1991,6 +2093,8 @@ export class Points extends CoreModule {
     // Fill sampled points FBO
     if (this.fillSampledPointsFboCommand && this.fillSampledPointsUniformStore && this.sampledPointsFbo) {
       if (!this.currentPositionTexture || this.currentPositionTexture.destroyed) return { indices, positions }
+      if (!this.exitTexture) this.updateExit()
+      if (!this.exitTexture || this.exitTexture.destroyed) return { indices, positions }
       // Update vertex count dynamically
       this.fillSampledPointsFboCommand.setVertexCount(this.data.pointsNumber ?? 0)
 
@@ -2006,6 +2110,7 @@ export class Points extends CoreModule {
       // Update texture bindings dynamically
       this.fillSampledPointsFboCommand.setBindings({
         positionsTexture: this.currentPositionTexture,
+        exitTexture: this.exitTexture,
       })
 
       const fillPass = this.device.beginRenderPass({
@@ -2169,6 +2274,11 @@ export class Points extends CoreModule {
       this.pinnedStatusTexture.destroy()
     }
     this.pinnedStatusTexture = undefined
+    if (this.exitTexture && !this.exitTexture.destroyed) {
+      this.exitTexture.destroy()
+    }
+    this.exitTexture = undefined
+    this.isExitTextureAllZero = false
 
     // 4. Destroy UniformStores (Models already destroyed their managed uniform buffers)
     this.interpolatePositionUniformStore?.destroy()
@@ -2211,6 +2321,7 @@ export class Points extends CoreModule {
     }
     this.targetSizeBuffer = undefined
     this.previousSizeData = undefined
+    this.previousExitData = undefined
     if (this.shapeBuffer && !this.shapeBuffer.destroyed) {
       this.shapeBuffer.destroy()
     }
@@ -2605,14 +2716,38 @@ export class Points extends CoreModule {
     for (let i = 0; i < points.length; i += 2) {
       const x = points[i] as number
       const y = points[i + 1] as number
+      // Skip absent (NaN) points: `Math.min/max(…, NaN)` is `NaN`, which would
+      // poison the extent and rescale every point to NaN (vanishing the graph).
+      if (Number.isNaN(x) || Number.isNaN(y)) continue
       minX = Math.min(minX, x)
       maxX = Math.max(maxX, x)
       minY = Math.min(minY, y)
       maxY = Math.max(maxY, y)
     }
+
+    // No finite points to rescale (all absent).
+    if (!Number.isFinite(minX)) return
+
     const w = maxX - minX
     const h = maxY - minY
     const range = Math.max(w, h)
+
+    // Degenerate bounding box (a single point, or all points coincident): there
+    // is nothing to scale, and dividing by `range === 0` would produce `NaN`
+    // positions, making the points vanish. Center them in the space instead,
+    // preserving any relative offsets.
+    if (range === 0) {
+      const center = spaceSize / 2
+      this.scaleX = (x: number): number => x - minX + center
+      this.scaleY = (y: number): number => y - minY + center
+      for (let i = 0; i < pointsNumber; i++) {
+        const x = points[i * 2] as number
+        if (Number.isNaN(x)) continue // leave absent points NaN
+        this.data.pointPositions[i * 2] = this.scaleX(x)
+        this.data.pointPositions[i * 2 + 1] = this.scaleY(points[i * 2 + 1] as number)
+      }
+      return
+    }
 
     // Do not rescale if the range is greater than the space size (no need to)
     if (range > spaceSize) {
@@ -2643,7 +2778,9 @@ export class Points extends CoreModule {
 
     // Apply scaling to point positions
     for (let i = 0; i < pointsNumber; i++) {
-      this.data.pointPositions[i * 2] = this.scaleX(points[i * 2] as number)
+      const x = points[i * 2] as number
+      if (Number.isNaN(x)) continue // leave absent points NaN
+      this.data.pointPositions[i * 2] = this.scaleX(x)
       this.data.pointPositions[i * 2 + 1] = this.scaleY(points[i * 2 + 1] as number)
     }
   }

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -22,7 +22,7 @@ import { getBytesPerRow } from '@/graph/modules/Shared/texture-utils'
 import trackPositionsFrag from '@/graph/modules/Points/track-positions.frag?raw'
 import dragPointFrag from '@/graph/modules/Points/drag-point.frag?raw'
 import updateVert from '@/graph/modules/Shared/quad.vert?raw'
-import { readPixels } from '@/graph/helper'
+import { readPixels, isPointAbsent } from '@/graph/helper'
 import { ensureVec2, ensureVec4 } from '@/graph/modules/Shared/uniform-utils'
 import { createAtlasDataFromImageData } from '@/graph/modules/Points/atlas-utils'
 import { buildPositionTextureData, buildSourcePositionTextureData } from '@/graph/modules/Points/position-utils'
@@ -2023,6 +2023,10 @@ export class Points extends CoreModule {
       const y = pixels[i * 4 + 1]
       const index = this.trackedIndices[i]
       if (x !== undefined && y !== undefined && index !== undefined) {
+        // Omit absent (removed) points — the tracked FBO holds their frozen last
+        // coordinate, which must not be reported as a live position. A missing key
+        // is the map's way of saying "this point is gone".
+        if (this.data.pointPositions && isPointAbsent(this.data.pointPositions, index)) continue
         tracked.set(index, [x, y])
       }
     }
@@ -2149,6 +2153,14 @@ export class Points extends CoreModule {
       const y = pixels[i * 4 + 1]
       const index = this.trackedIndices[i]
       if (x !== undefined && y !== undefined && index !== undefined) {
+        // An absent (removed) point reads back as NaN. Unlike the map (which omits
+        // it), the array must keep the slot so positions stay aligned with the
+        // tracked indices.
+        if (this.data.pointPositions && isPointAbsent(this.data.pointPositions, index)) {
+          positions[i * 2] = NaN
+          positions[i * 2 + 1] = NaN
+          continue
+        }
         positions[i * 2] = x
         positions[i * 2 + 1] = y
       }

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -28,6 +28,9 @@ import { createAtlasDataFromImageData } from '@/graph/modules/Points/atlas-utils
 import { buildPositionTextureData, buildSourcePositionTextureData } from '@/graph/modules/Points/position-utils'
 import { Transition, TransitionProperty } from '@/graph/modules/Transition'
 
+/** Exact GLSL float literal for a shader `#define` (`.toFixed` would round non-integers). */
+const glslFloatLiteral = (value: number): string => (Number.isInteger(value) ? value.toFixed(1) : String(value))
+
 export class Points extends CoreModule {
   public transition: Transition | undefined
   public currentPositionFbo: Framebuffer | undefined
@@ -673,13 +676,14 @@ export class Points extends CoreModule {
         { name: 'imageIndex', format: 'float32' },
         { name: 'imageSize', format: 'float32' },
       ],
+      // Cast: luma types `defines` boolean-only, but its runtime injects any value
+      // verbatim as `#define KEY value` — which is how the shared exit defaults
+      // (variables.ts) reach the shader.
       defines: {
         USE_UNIFORM_BUFFERS: true,
-        // Exit defaults shared with the CPU resolvers (variables.ts) — formatted as
-        // exact GLSL float literals (`.toFixed` would round non-integer values).
-        EXIT_DEFAULT_SIZE: Number.isInteger(EXIT_DEFAULT_SIZE) ? EXIT_DEFAULT_SIZE.toFixed(1) : String(EXIT_DEFAULT_SIZE),
-        EXIT_DEFAULT_COLOR_CHANNEL: Number.isInteger(EXIT_DEFAULT_COLOR_CHANNEL) ? EXIT_DEFAULT_COLOR_CHANNEL.toFixed(1) : String(EXIT_DEFAULT_COLOR_CHANNEL),
-      },
+        EXIT_DEFAULT_SIZE: glslFloatLiteral(EXIT_DEFAULT_SIZE),
+        EXIT_DEFAULT_COLOR_CHANNEL: glslFloatLiteral(EXIT_DEFAULT_COLOR_CHANNEL),
+      } as unknown as Record<string, boolean>,
       bindings: {
         // Create uniform buffer binding
         // Update it later by calling uniformStore.setUniforms()

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -69,11 +69,18 @@ export class Points extends CoreModule {
   public previousPositionTexture: Texture | undefined
   public velocityTexture: Texture | undefined
   public pointStatusTexture: Texture | undefined
-  // Exit status, derived from NaN positions (R = previous absence, G = current
-  // absence; 1 = absent). The single source of truth for "is this point leaving /
-  // gone": draw blends R→G by transition progress for the fade gone-guard, while
-  // the integrator and force modules read G to exclude absent points from physics.
-  // Public so the force modules can sample it.
+  /**
+   * Exit status, derived from NaN positions (R = previous absence, G = current
+   * absence; 1 = absent). The single source of truth for "is this point leaving /
+   * gone": draw blends R→G by transition progress for the fade gone-guard, while
+   * the integrator and force modules read G to exclude absent points from physics.
+   * Public so the force modules can sample it.
+   *
+   * While no point is (or was) absent — the common no-NaN case — this is a 1×1
+   * all-zero stand-in: any sample returns "present", the texel stays
+   * cache-resident so the per-vertex fetch costs ~nothing, and the full-size
+   * texture is never allocated.
+   */
   public exitTexture: Texture | undefined
   /**
    * Start of a position transition — the "from" positions blended by
@@ -103,12 +110,16 @@ export class Points extends CoreModule {
   private sourceSizeBuffer: Buffer | undefined
   private targetSizeBuffer: Buffer | undefined
   private previousSizeData: Float32Array | undefined
-  // Previous-frame absence per point (1 = absent), kept so the next `updateExit`
-  // can fill the exit texture's R (previous) channel.
+  /**
+   * Previous-frame absence per point (1 = absent), kept so the next `updateExit`
+   * can fill the exit texture's R (previous) channel.
+   */
   private previousExitData: Float32Array | undefined
-  // True when the exit texture is entirely zero (no point absent now or last
-  // frame). Lets `updateExit` skip the alloc + upload on the common no-NaN path.
-  private isExitTextureAllZero = false
+  /**
+   * Whether any point is absent as of the latest update (= any(`previousExitData`)),
+   * stored so the next `updateExit` doesn't rescan for it.
+   */
+  private hasAnyAbsentPoint = false
   private shapeBuffer: Buffer | undefined
   private imageIndicesBuffer: Buffer | undefined
   private imageSizesBuffer: Buffer | undefined
@@ -1132,48 +1143,65 @@ export class Points extends CoreModule {
     }
   }
 
-  // Builds the exit texture from point positions: R = previous absence, G = current
-  // absence (1 = NaN position). One signal for both pipelines: the draw shader
-  // blends R→G by transition progress (the fade gone-guard), and the integrator
-  // and force shaders read G to skip absent points so a NaN never poisons physics.
+  /**
+   * Builds the exit texture from point positions: R = previous absence, G = current
+   * absence (1 = NaN position). One signal for both pipelines: the draw shader
+   * blends R→G by transition progress (the fade gone-guard), and the integrator
+   * and force shaders read G to skip absent points so a NaN never poisons physics.
+   * The texture is rg32float — two channels are all the state there is.
+   */
   public updateExit (): void {
     const { device, store: { pointsTextureSize }, data } = this
     if (!pointsTextureSize) return
 
     const count = data.pointsNumber ?? 0
     const prev = this.previousExitData
+    const anyAbsentBefore = this.hasAnyAbsentPoint
 
     // Cheap scan: current absence per point, and whether anything is absent now.
-    const nextPrevious = new Float32Array(count)
+    const currentAbsence = new Float32Array(count)
     let anyAbsentNow = false
     for (let i = 0; i < count; i++) {
       const current = data.pointPositions && isPointAbsent(data.pointPositions, i) ? 1 : 0
-      nextPrevious[i] = current
+      currentAbsence[i] = current
       if (current) anyAbsentNow = true
     }
-    let anyAbsentBefore = false
-    if (prev) for (let i = 0; i < prev.length; i++) if (prev[i]) { anyAbsentBefore = true; break }
+    this.previousExitData = currentAbsence
+    this.hasAnyAbsentPoint = anyAbsentNow
 
-    const sameSize = !!this.exitTexture && this.exitTexture.width === pointsTextureSize && this.exitTexture.height === pointsTextureSize
-
-    // Fast path for the common (no-NaN) case: the texture would be all-zero (no R
-    // or G set) and the existing one already is — skip the big alloc + GPU upload.
-    if (!anyAbsentNow && !anyAbsentBefore && sameSize && this.isExitTextureAllZero) {
-      this.previousExitData = nextPrevious
+    // Common (no-NaN) case: every texel would be zero, so bind a 1×1 all-zero
+    // stand-in instead of a pointsTextureSize² texture. Any sample of it returns
+    // "present", it stays cache-resident so the per-vertex fetch in the hot shaders
+    // costs ~nothing, and the full-size texture is never allocated or uploaded.
+    if (!anyAbsentNow && !anyAbsentBefore) {
+      if (this.exitTexture && !this.exitTexture.destroyed && this.exitTexture.width === 1) return
+      if (this.exitTexture && !this.exitTexture.destroyed) {
+        this.exitTexture.destroy()
+      }
+      this.exitTexture = device.createTexture({ width: 1, height: 1, format: 'rg32float' })
+      this.exitTexture.copyImageData({
+        data: new Float32Array(2),
+        bytesPerRow: getBytesPerRow('rg32float', 1),
+        mipLevel: 0,
+        x: 0,
+        y: 0,
+      })
       return
     }
 
-    // Build R = previous absence, G = current absence.
-    const state = new Float32Array(pointsTextureSize * pointsTextureSize * 4)
+    // Build R = previous absence, G = current absence (RG pairs, one per texel).
+    const state = new Float32Array(pointsTextureSize * pointsTextureSize * 2)
     for (let i = 0; i < count; i++) {
-      const current = nextPrevious[i] as number
+      const current = currentAbsence[i] as number
       // New slots (no history) start with previous = current, so no spurious fade.
       const previous = i < (prev?.length ?? 0) ? (prev as Float32Array)[i] as number : current
-      state[i * 4] = previous
-      state[i * 4 + 1] = current
+      state[i * 2] = previous
+      state[i * 2 + 1] = current
     }
-    this.previousExitData = nextPrevious
 
+    // The 1×1 stand-in (or a stale size after a texture resize) fails this check
+    // and is replaced by the full-size texture.
+    const sameSize = !!this.exitTexture && this.exitTexture.width === pointsTextureSize && this.exitTexture.height === pointsTextureSize
     if (!this.exitTexture || !sameSize) {
       if (this.exitTexture && !this.exitTexture.destroyed) {
         this.exitTexture.destroy()
@@ -1181,18 +1209,16 @@ export class Points extends CoreModule {
       this.exitTexture = device.createTexture({
         width: pointsTextureSize,
         height: pointsTextureSize,
-        format: 'rgba32float',
+        format: 'rg32float',
       })
     }
     this.exitTexture.copyImageData({
       data: state,
-      bytesPerRow: getBytesPerRow('rgba32float', pointsTextureSize),
+      bytesPerRow: getBytesPerRow('rg32float', pointsTextureSize),
       mipLevel: 0,
       x: 0,
       y: 0,
     })
-    // The texture is all-zero iff no point is (or was) absent.
-    this.isExitTextureAllZero = !anyAbsentNow && !anyAbsentBefore
   }
 
   public updateSize (): void {
@@ -2290,7 +2316,7 @@ export class Points extends CoreModule {
       this.exitTexture.destroy()
     }
     this.exitTexture = undefined
-    this.isExitTextureAllZero = false
+    this.hasAnyAbsentPoint = false
 
     // 4. Destroy UniformStores (Models already destroyed their managed uniform buffers)
     this.interpolatePositionUniformStore?.destroy()
@@ -2737,8 +2763,14 @@ export class Points extends CoreModule {
       maxY = Math.max(maxY, y)
     }
 
-    // No finite points to rescale (all absent).
-    if (!Number.isFinite(minX)) return
+    // No finite points to rescale (all absent): no scale exists for this data —
+    // clear any previous dataset's closures so getScaleX/getScaleY don't report a
+    // stale mapping (same contract as the range > spaceSize branch below).
+    if (!Number.isFinite(minX)) {
+      this.scaleX = undefined
+      this.scaleY = undefined
+      return
+    }
 
     const w = maxX - minX
     const h = maxY - minY

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -4,7 +4,7 @@ import { Model } from '@luma.gl/engine'
 // import { extent } from 'd3-array'
 import { CoreModule } from '@/graph/modules/core-module'
 import type { Mat4Array } from '@/graph/modules/Store'
-import { defaultConfigValues } from '@/graph/variables'
+import { defaultConfigValues, EXIT_DEFAULT_SIZE, EXIT_DEFAULT_COLOR_CHANNEL } from '@/graph/variables'
 import drawPointsFrag from '@/graph/modules/Points/draw-points.frag?raw'
 import drawPointsVert from '@/graph/modules/Points/draw-points.vert?raw'
 import findPointsInRectFrag from '@/graph/modules/Points/find-points-in-rect.frag?raw'
@@ -22,7 +22,7 @@ import { getBytesPerRow } from '@/graph/modules/Shared/texture-utils'
 import trackPositionsFrag from '@/graph/modules/Points/track-positions.frag?raw'
 import dragPointFrag from '@/graph/modules/Points/drag-point.frag?raw'
 import updateVert from '@/graph/modules/Shared/quad.vert?raw'
-import { readPixels, isPointAbsent } from '@/graph/helper'
+import { readPixels, isPointAbsent, getRgbaColor } from '@/graph/helper'
 import { ensureVec2, ensureVec4 } from '@/graph/modules/Shared/uniform-utils'
 import { createAtlasDataFromImageData } from '@/graph/modules/Points/atlas-utils'
 import { buildPositionTextureData, buildSourcePositionTextureData } from '@/graph/modules/Points/position-utils'
@@ -219,6 +219,9 @@ export class Points extends CoreModule {
       transitionProgress: number;
       animateColors: number;
       animateSizes: number;
+      animatePositions: number;
+      pointDefaultColor: [number, number, number, number];
+      pointDefaultSize: number;
     };
     drawFragmentUniforms: {
       greyoutOpacity: number;
@@ -266,6 +269,7 @@ export class Points extends CoreModule {
       maxPointSize: number;
       skipHighlighted: number;
       skipGreyed: number;
+      pointDefaultSize: number;
     };
   }> | undefined
 
@@ -586,6 +590,8 @@ export class Points extends CoreModule {
           animateColors: 'f32',
           animateSizes: 'f32',
           animatePositions: 'f32',
+          pointDefaultColor: 'vec4<f32>',
+          pointDefaultSize: 'f32',
         },
         defaultUniforms: {
           // Order MUST match uniformTypes and shader declaration
@@ -617,6 +623,8 @@ export class Points extends CoreModule {
           animateColors: 0,
           animateSizes: 0,
           animatePositions: 0,
+          pointDefaultColor: ensureVec4(getRgbaColor(config.pointDefaultColor), [0, 0, 0, 1]),
+          pointDefaultSize: config.pointDefaultSize,
         },
       },
       drawFragmentUniforms: {
@@ -667,6 +675,10 @@ export class Points extends CoreModule {
       ],
       defines: {
         USE_UNIFORM_BUFFERS: true,
+        // Exit defaults shared with the CPU resolvers (variables.ts) — formatted as
+        // GLSL float literals.
+        EXIT_DEFAULT_SIZE: EXIT_DEFAULT_SIZE.toFixed(1),
+        EXIT_DEFAULT_COLOR_CHANNEL: EXIT_DEFAULT_COLOR_CHANNEL.toFixed(1),
       },
       bindings: {
         // Create uniform buffer binding
@@ -807,6 +819,7 @@ export class Points extends CoreModule {
           maxPointSize: 'f32',
           skipHighlighted: 'f32',
           skipGreyed: 'f32',
+          pointDefaultSize: 'f32',
         },
         defaultUniforms: {
           pointsTextureSize: store.pointsTextureSize ?? 0,
@@ -820,6 +833,7 @@ export class Points extends CoreModule {
           maxPointSize: store.maxPointSize,
           skipHighlighted: 0,
           skipGreyed: 0,
+          pointDefaultSize: config.pointDefaultSize,
         },
       },
     })
@@ -1548,6 +1562,8 @@ export class Points extends CoreModule {
       animateColors: this.shouldAnimatePointColors ? 1 : 0,
       animateSizes: this.shouldAnimatePointSizes ? 1 : 0,
       animatePositions: this.shouldAnimatePointPositions ? 1 : 0,
+      pointDefaultColor: ensureVec4(getRgbaColor(config.pointDefaultColor), [0, 0, 0, 1]),
+      pointDefaultSize: config.pointDefaultSize,
     }
 
     const baseFragmentUniforms = {
@@ -1629,7 +1645,7 @@ export class Points extends CoreModule {
     if (config.renderHoveredPointRing && store.hoveredPoint && this.drawHighlightedCommand && this.drawHighlightedUniformStore) {
       if (!this.currentPositionTexture || this.currentPositionTexture.destroyed) return
       if (!this.pointStatusTexture || this.pointStatusTexture.destroyed) return
-      const pointSize = data.pointSizes?.[store.hoveredPoint.index] ?? 1
+      const pointSize = data.getResolvedPointSize(store.hoveredPoint.index)
       const imageSize = data.pointImageSizes?.[store.hoveredPoint.index] ?? pointSize
       this.drawHighlightedUniformStore.setUniforms({
         drawHighlightedUniforms: {
@@ -1664,7 +1680,7 @@ export class Points extends CoreModule {
     if (store.focusedPoint && this.drawHighlightedCommand && this.drawHighlightedUniformStore) {
       if (!this.currentPositionTexture || this.currentPositionTexture.destroyed) return
       if (!this.pointStatusTexture || this.pointStatusTexture.destroyed) return
-      const pointSize = data.pointSizes?.[store.focusedPoint.index] ?? 1
+      const pointSize = data.getResolvedPointSize(store.focusedPoint.index)
       const imageSize = data.pointImageSizes?.[store.focusedPoint.index] ?? pointSize
       this.drawHighlightedUniformStore.setUniforms({
         drawHighlightedUniforms: {
@@ -1908,6 +1924,7 @@ export class Points extends CoreModule {
       scalePointsOnZoom: this.config.scalePointsOnZoom ? 1 : 0,
       mousePosition: ensureVec2(this.store.screenMousePosition, [0, 0]),
       maxPointSize: this.store.maxPointSize,
+      pointDefaultSize: this.config.pointDefaultSize,
     }
 
     const bindings = {

--- a/src/modules/Points/interpolate-position.frag
+++ b/src/modules/Points/interpolate-position.frag
@@ -23,7 +23,8 @@ out vec4 fragColor;
 void main() {
   vec4 source = texture(sourceTexture, textureCoords);
   vec4 target = texture(targetTexture, textureCoords);
-  // NaN means absent. Hold the real side so the point stays put while it fades,
+  // NaN means absent (ingest normalizes half-NaN to full-NaN, so checking one
+  // channel suffices). Hold the real side so the point stays put while it fades,
   // never interpolating to/from NaN:
   //   · exiting  (target NaN): freeze at source.
   //   · entering (source NaN): appear at target (no slide in from NaN).

--- a/src/modules/Points/interpolate-position.frag
+++ b/src/modules/Points/interpolate-position.frag
@@ -23,6 +23,12 @@ out vec4 fragColor;
 void main() {
   vec4 source = texture(sourceTexture, textureCoords);
   vec4 target = texture(targetTexture, textureCoords);
-  vec2 position = mix(source.rg, target.rg, progress);
+  // NaN means absent. Hold the real side so the point stays put while it fades,
+  // never interpolating to/from NaN:
+  //   · exiting  (target NaN): freeze at source.
+  //   · entering (source NaN): appear at target (no slide in from NaN).
+  vec2 src = isnan(source.r) ? target.rg : source.rg;
+  vec2 tgt = isnan(target.r) ? src : target.rg;
+  vec2 position = mix(src, tgt, progress);
   fragColor = vec4(position, source.b, 1.0);
 }

--- a/src/modules/Points/position-utils.ts
+++ b/src/modules/Points/position-utils.ts
@@ -1,3 +1,5 @@
+import { isPointAbsent } from '@/graph/helper'
+
 /**
  * Build RGBA32F texture data from a flat `[x, y, x, y, ...]` point positions array.
  *
@@ -13,8 +15,11 @@ export function buildPositionTextureData (
   if (!pointPositions) return positionData
 
   for (let i = 0; i < pointsNumber; ++i) {
-    positionData[i * 4 + 0] = pointPositions[i * 2 + 0] as number
-    positionData[i * 4 + 1] = pointPositions[i * 2 + 1] as number
+    // Normalize a half-NaN position to fully NaN: absence is all-or-nothing by the
+    // time it reaches the GPU, so shaders can test a single channel.
+    const absent = isPointAbsent(pointPositions, i)
+    positionData[i * 4 + 0] = absent ? NaN : pointPositions[i * 2 + 0] as number
+    positionData[i * 4 + 1] = absent ? NaN : pointPositions[i * 2 + 1] as number
     positionData[i * 4 + 2] = i
   }
 

--- a/src/modules/Points/update-position.frag
+++ b/src/modules/Points/update-position.frag
@@ -6,6 +6,7 @@ precision highp float;
 uniform sampler2D positionsTexture;
 uniform sampler2D velocity;
 uniform sampler2D pinnedStatusTexture;
+uniform sampler2D exitTexture;
 
 #ifdef USE_UNIFORM_BUFFERS
 layout(std140) uniform updatePositionUniforms {
@@ -35,6 +36,14 @@ void main() {
   
   // If pinned, don't update position
   if (pinnedStatus.r > 0.5) {
+    fragColor = pointPosition;
+    return;
+  }
+
+  // If absent (current absence = exit.G), leave it untouched — don't integrate or
+  // clamp it (clamping NaN is undefined and could resurrect the point at (0,0)).
+  vec4 exitStatus = texture(exitTexture, textureCoords);
+  if (exitStatus.g > 0.5) {
     fragColor = pointPosition;
     return;
   }

--- a/src/modules/Transition/index.ts
+++ b/src/modules/Transition/index.ts
@@ -65,9 +65,38 @@ export class Transition {
   private pendingProperties = new Set<TransitionProperty>()
   /** Properties currently animating in the running cycle. */
   private activeProperties = new Set<TransitionProperty>()
+  /** One-shot duration (ms) for the next cycle, set via `setNextDuration`. Consumed by `start()`. */
+  private overrideDuration?: number
+  /**
+   * Duration (ms) the running animation remembers for all its frames.
+   *
+   * Matters whenever an animation with a custom duration is playing — especially
+   * if another update can arrive before it finishes: `start()` copies the one-shot
+   * override here and clears the override right away, so an interrupting update
+   * isn't affected by this one's override, while this animation still knows its own
+   * length frame to frame.
+   */
+  private activeDuration = 0
 
   public constructor (config: GraphConfigInterface) {
     this.config = config
+  }
+
+  /**
+   * How long the *next* update's transition should last (ms). A duration of 0 means
+   * the next update snaps instead of animating.
+   *
+   * Priority:
+   *   1. a one-shot override from `setNextTransitionDuration()`, if set;
+   *   2. else the running cycle's duration, if one is active;
+   *   3. else the config default.
+   *
+   * The override wins even mid-animation, so `setNextTransitionDuration(0)` always
+   * snaps the next update. This only affects the next update — a transition that is
+   * already playing keeps its own length (`step()` uses `activeDuration` directly).
+   */
+  public get duration (): number {
+    return this.overrideDuration ?? (this.isActive ? this.activeDuration : this.config.transitionDuration)
   }
 
   /** True while one or more properties are queued via `queue()` awaiting `start()`. */
@@ -101,6 +130,15 @@ export class Transition {
   }
 
   /**
+   * Sets a one-shot duration (ms) for the next cycle only, overriding
+   * `config.transitionDuration`. `0` snaps with no animation; `undefined` falls
+   * back to config. Consumed when the next cycle starts.
+   */
+  public setNextDuration (duration?: number): void {
+    this.overrideDuration = duration
+  }
+
+  /**
    * Starts a queued transition cycle.
    *
    * - No pending queue → no-op.
@@ -113,7 +151,9 @@ export class Transition {
   public start (): void {
     if (!this.isPending) return
 
-    const { transitionDuration } = this.config
+    // Consume the one-shot override (if any) so it applies to this cycle only.
+    const transitionDuration = this.overrideDuration ?? this.config.transitionDuration
+    this.overrideDuration = undefined
 
     if (transitionDuration <= 0) {
       const wasActive = this.isActive
@@ -127,6 +167,7 @@ export class Transition {
       this.end(true)
     }
 
+    this.activeDuration = transitionDuration
     this.startTime = performance.now()
     this.progress = 0
     this.activeProperties = new Set(this.pendingProperties)
@@ -145,7 +186,7 @@ export class Transition {
   public step (): void {
     if (!this.isActive) return
 
-    const { transitionDuration } = this.config
+    const transitionDuration = this.activeDuration
 
     if (transitionDuration <= 0) {
       this.end(true)

--- a/src/modules/Transition/index.ts
+++ b/src/modules/Transition/index.ts
@@ -58,14 +58,15 @@ const easingFunctions: Record<TransitionEasing, (t: number) => number> = {
 /**
  * Drives timed transitions (positions / colors / sizes / …) between data updates.
  *
- * Three durations, at three scopes:
- * - `config.transitionDuration` — the default, **forever**;
- * - `overrideDuration` — **this render only** (set by `setDurationOverride()` before the update
- *   pipeline, consumed by `start()`);
- * - `activeDuration` — **this animation only** (frozen at `start()`, read each frame by `step()`).
+ * Three durations, three scopes:
+ * - `config.transitionDuration` — the default (app lifetime);
+ * - `overrideDuration` — the plan for the next cycle (this render only; armed by
+ *   `setDurationOverride()`, consumed by `start()`);
+ * - `activeDuration` — the running cycle's memory (set by `start()`, paces `step()`).
  *
- * The `duration` getter resolves them in that precedence: the render override, else the running
- * cycle's duration while one is active, else the config default.
+ * The `duration` getter (override, else config) is the single rule for the next cycle: `start()`
+ * resolves through it, so code predicting animate vs. snap always matches what `start()` does.
+ * The cycle's memory never feeds back into that rule.
  */
 export class Transition {
   /** Last eased progress value in the `[0, 1]` range. */
@@ -99,15 +100,12 @@ export class Transition {
   }
 
   /**
-   * How long the upcoming transition lasts (ms): the value armed for this render if any, else the
-   * running cycle's duration while one is active, else the config default. A duration of 0 means
-   * the update snaps instead of animating.
-   *
-   * A transition that is already playing keeps its own length (`step()` uses `activeDuration`
-   * directly).
+   * Duration (ms) the next `start()` will use: the render override if armed, else the config
+   * default. `0` means snap. `start()` resolves through this same getter, so predicting
+   * animate vs. snap before it runs always matches what it does.
    */
   public get duration (): number {
-    return this.overrideDuration ?? (this.isActive ? this.activeDuration : this.config.transitionDuration)
+    return this.overrideDuration ?? this.config.transitionDuration
   }
 
   /** True while one or more properties are queued via `queue()` awaiting `start()`. */
@@ -163,9 +161,8 @@ export class Transition {
    * `config.transitionDuration`, and clears the override so it applies once.
    */
   public start (): void {
-    // Consume the render override unconditionally, so it can't linger into a later render even
-    // when there's nothing pending to start.
-    const transitionDuration = this.overrideDuration ?? this.config.transitionDuration
+    // Consume the override even when nothing is pending, so it can't linger into a later render.
+    const transitionDuration = this.duration
     this.overrideDuration = undefined
 
     if (!this.isPending) return

--- a/src/modules/Transition/index.ts
+++ b/src/modules/Transition/index.ts
@@ -55,6 +55,18 @@ const easingFunctions: Record<TransitionEasing, (t: number) => number> = {
   [TransitionEasing.CircleInOut]: easeCircleInOut,
 }
 
+/**
+ * Drives timed transitions (positions / colors / sizes / …) between data updates.
+ *
+ * Three durations, at three scopes:
+ * - `config.transitionDuration` — the default, **forever**;
+ * - `overrideDuration` — **this render only** (set by `setDurationOverride()` before the update
+ *   pipeline, consumed by `start()`);
+ * - `activeDuration` — **this animation only** (frozen at `start()`, read each frame by `step()`).
+ *
+ * The `duration` getter resolves them in that precedence: the render override, else the running
+ * cycle's duration while one is active, else the config default.
+ */
 export class Transition {
   /** Last eased progress value in the `[0, 1]` range. */
   public progress = 1
@@ -65,16 +77,20 @@ export class Transition {
   private pendingProperties = new Set<TransitionProperty>()
   /** Properties currently animating in the running cycle. */
   private activeProperties = new Set<TransitionProperty>()
-  /** One-shot duration (ms) for the next cycle, set via `setNextDuration`. Consumed by `start()`. */
+  /**
+   * Duration (ms) overriding `config.transitionDuration` for the cycle this render is about to
+   * start. Set by `setDurationOverride()` before the update pipeline (which reads `duration` to
+   * decide animate vs. snap), consumed by `start()`. `render()` sets it before every `start()`,
+   * so an override never carries into another render.
+   */
   private overrideDuration?: number
   /**
    * Duration (ms) the running animation remembers for all its frames.
    *
    * Matters whenever an animation with a custom duration is playing — especially
-   * if another update can arrive before it finishes: `start()` copies the one-shot
-   * override here and clears the override right away, so an interrupting update
-   * isn't affected by this one's override, while this animation still knows its own
-   * length frame to frame.
+   * if another update can arrive before it finishes: `start()` records the cycle's
+   * duration here, so an interrupting update with a different duration doesn't
+   * affect this one, which still knows its own length frame to frame.
    */
   private activeDuration = 0
 
@@ -83,17 +99,12 @@ export class Transition {
   }
 
   /**
-   * How long the *next* update's transition should last (ms). A duration of 0 means
-   * the next update snaps instead of animating.
+   * How long the upcoming transition lasts (ms): the value armed for this render if any, else the
+   * running cycle's duration while one is active, else the config default. A duration of 0 means
+   * the update snaps instead of animating.
    *
-   * Priority:
-   *   1. a one-shot override from `setNextTransitionDuration()`, if set;
-   *   2. else the running cycle's duration, if one is active;
-   *   3. else the config default.
-   *
-   * The override wins even mid-animation, so `setNextTransitionDuration(0)` always
-   * snaps the next update. This only affects the next update — a transition that is
-   * already playing keeps its own length (`step()` uses `activeDuration` directly).
+   * A transition that is already playing keeps its own length (`step()` uses `activeDuration`
+   * directly).
    */
   public get duration (): number {
     return this.overrideDuration ?? (this.isActive ? this.activeDuration : this.config.transitionDuration)
@@ -107,6 +118,15 @@ export class Transition {
   /** True between `start()` and the end of the cycle. */
   public get isActive (): boolean {
     return this.activeProperties.size > 0
+  }
+
+  /**
+   * Overrides `config.transitionDuration` for the transition this render will start, for this
+   * render only. `undefined` (or a non-finite value) falls back to config. Called by `render()`
+   * before the update pipeline runs, and consumed by `start()`.
+   */
+  public setDurationOverride (duration?: number): void {
+    this.overrideDuration = (duration !== undefined && Number.isFinite(duration)) ? duration : undefined
   }
 
   /** Reports whether a specific property is queued and awaiting `start()`. */
@@ -130,35 +150,25 @@ export class Transition {
   }
 
   /**
-   * Sets a one-shot duration (ms) for the next cycle only, overriding
-   * `config.transitionDuration`. `0` snaps with no animation; `undefined` falls
-   * back to config. Consumed when the next cycle starts.
-   *
-   * A non-finite duration (NaN, Infinity) is rejected and ignored: it would flow
-   * into `activeDuration` and leave `step()` unable to reach progress 1, so the
-   * cycle would never end.
-   */
-  public setNextDuration (duration?: number): void {
-    if (duration !== undefined && !Number.isFinite(duration)) return
-    this.overrideDuration = duration
-  }
-
-  /**
    * Starts a queued transition cycle.
    *
    * - No pending queue → no-op.
-   * - `transitionDuration > 0` → begin cycle; fire `onTransitionStart`.
-   * - `transitionDuration <= 0` → pending is discarded; no cycle begins.
+   * - `duration > 0` → begin cycle; fire `onTransitionStart`.
+   * - `duration <= 0` → pending is discarded; no cycle begins.
    *
    * In either non-no-op path, any active cycle is reported as interrupted
    * via `onTransitionEnd(true)` before the new state takes effect.
+   *
+   * Uses the render override from `setDurationOverride()` (if any), else
+   * `config.transitionDuration`, and clears the override so it applies once.
    */
   public start (): void {
-    if (!this.isPending) return
-
-    // Consume the one-shot override (if any) so it applies to this cycle only.
+    // Consume the render override unconditionally, so it can't linger into a later render even
+    // when there's nothing pending to start.
     const transitionDuration = this.overrideDuration ?? this.config.transitionDuration
     this.overrideDuration = undefined
+
+    if (!this.isPending) return
 
     if (transitionDuration <= 0) {
       const wasActive = this.isActive
@@ -227,7 +237,6 @@ export class Transition {
    */
   public abort (): void {
     this.pendingProperties.clear()
-    // Drop the one-shot override too, so it can't leak into a later cycle.
     this.overrideDuration = undefined
     this.clearActiveCycle()
   }

--- a/src/modules/Transition/index.ts
+++ b/src/modules/Transition/index.ts
@@ -133,8 +133,13 @@ export class Transition {
    * Sets a one-shot duration (ms) for the next cycle only, overriding
    * `config.transitionDuration`. `0` snaps with no animation; `undefined` falls
    * back to config. Consumed when the next cycle starts.
+   *
+   * A non-finite duration (NaN, Infinity) is rejected and ignored: it would flow
+   * into `activeDuration` and leave `step()` unable to reach progress 1, so the
+   * cycle would never end.
    */
   public setNextDuration (duration?: number): void {
+    if (duration !== undefined && !Number.isFinite(duration)) return
     this.overrideDuration = duration
   }
 
@@ -222,6 +227,8 @@ export class Transition {
    */
   public abort (): void {
     this.pendingProperties.clear()
+    // Drop the one-shot override too, so it can't leak into a later cycle.
+    this.overrideDuration = undefined
     this.clearActiveCycle()
   }
 

--- a/src/modules/Zoom/index.ts
+++ b/src/modules/Zoom/index.ts
@@ -75,11 +75,17 @@ export class Zoom {
     for (let i = 0; i < positions.length; i += 2) {
       const x = positions[i] as number
       const y = positions[i + 1] as number
+      // Skip non-finite positions (absent/removed points) — they must not affect the extent.
+      if (!Number.isFinite(x) || !Number.isFinite(y)) continue
       if (x < minX) minX = x
       if (x > maxX) maxX = x
       if (y < minY) minY = y
       if (y > maxY) maxY = y
     }
+
+    // No finite position to fit (e.g. every given point is absent): keep the current view.
+    // Proceeding would produce a NaN transform and blank the canvas.
+    if (!Number.isFinite(minX) || !Number.isFinite(minY)) return this.eventTransform
 
     const xExtent: [number, number] = [this.store.scaleX(minX), this.store.scaleX(maxX)]
     const yExtent: [number, number] = [this.store.scaleY(minY), this.store.scaleY(maxY)]
@@ -117,6 +123,9 @@ export class Zoom {
   }
 
   public getMiddlePointTransform (position: [number, number]): ZoomTransform {
+    // A non-finite target has no middle point — keep the current view rather than
+    // emitting a NaN transform.
+    if (!Number.isFinite(position[0]) || !Number.isFinite(position[1])) return this.eventTransform
     const { store: { screenSize }, eventTransform: { x, y, k } } = this
     const width = screenSize[0]
     const height = screenSize[1]

--- a/src/stories/3. api-reference.mdx
+++ b/src/stories/3. api-reference.mdx
@@ -94,7 +94,7 @@ positions[i * 2 + 1] = NaN;
 graph.setPointPositions(positions);
 ```
 
-By default an absent point fades to nothing (size and opacity → 0). To customize the exit look, pass per-point values via `setPointSizes` / `setPointColors` (e.g. recolor while fading); a `NaN` entry in those arrays means "use the exit default" for an absent point. This works with the simulation on or off — a `NaN` position is excluded from the force layout rather than corrupting it. Adding a point is the mirror (`NaN → real`, fades in). cosmos.gl does not auto-compact away the gaps — drop them yourself when convenient and snap the renumber with [`setNextTransitionDuration(0)`](#set_next_transition_duration). See the **Examples / Beginners → Add & Remove Points** story.
+By default an absent point fades to nothing (size and opacity → 0). To customize the exit look, pass per-point values via `setPointSizes` / `setPointColors` (e.g. recolor while fading); a `NaN` entry in those arrays means "use the exit default" for an absent point. This works with the simulation on or off — a `NaN` position is excluded from the force layout rather than corrupting it. Adding a point is the mirror (`NaN → real`, fades in). cosmos.gl does not auto-compact away the gaps — drop them yourself when convenient and snap the renumber with [`render(undefined, 0)`](#render). See the **Examples / Beginners → Add & Remove Points** story.
 
 **Example:**
 ```javascript
@@ -399,7 +399,7 @@ Sets which points are pinned (fixed) in position. Pinned points do not move due 
   graph.setPinnedPoints(null)
   ```
 
-### <a name="render" href="#render">#</a> graph.<b>render</b>([<i>simulationAlpha</i>])
+### <a name="render" href="#render">#</a> graph.<b>render</b>([<i>simulationAlpha</i>], [<i>transitionDuration</i>])
 
 The `render` method renders the graph and starts rendering. It does NOT modify simulation state - use `start()`, `stop()`, `pause()`, or `unpause()` to control the simulation.
 
@@ -407,23 +407,17 @@ The `render` method renders the graph and starts rendering. It does NOT modify s
   - If `0`: Sets alpha to 0, simulation stops after one frame (graph becomes static).
   - If positive: Sets alpha to that value.
   - If `undefined`: Keeps current alpha value.
+* **`transitionDuration`** (Number, optional): Duration in milliseconds for any transition this render starts (from setters called before it), for this call only. `0` snaps (no animation); a positive value animates for that long; `undefined` falls back to `config.transitionDuration`. To snap without changing the alpha, call `graph.render(undefined, 0)`.
 
-**Transitions:** If any setter (`setPointPositions`, `setPointColors`, `setPointSizes`, `setLinkColors`, `setLinkWidths`) has queued changes and `transitionDuration > 0`, `render()` starts an animated transition. When the simulation is running, only **position** transitions auto-pause it (and `onSimulationPause` fires), and the simulation stays paused afterwards until `unpause()` is called. The first render after initialization always snaps position changes — there is no prior state to animate from. See [Transitions](../?path=/docs/configuration--docs#transitions) in the configuration docs.
+**Transitions:** If any setter (`setPointPositions`, `setPointColors`, `setPointSizes`, `setLinkColors`, `setLinkWidths`) has queued changes and the effective duration is `> 0`, `render()` starts an animated transition. The per-call `transitionDuration` applies to the whole update — every setter you called before this `render()` — and wins even while another transition is still playing. When the simulation is running, only **position** transitions auto-pause it (and `onSimulationPause` fires), and the simulation stays paused afterwards until `unpause()` is called. The first render after initialization always snaps position changes — there is no prior state to animate from. See [Transitions](../?path=/docs/configuration--docs#transitions) in the configuration docs.
 
-### <a name="set_next_transition_duration" href="#set_next_transition_duration">#</a> graph.<b>setNextTransitionDuration</b>([<i>duration</i>])
-
-Overrides `config.transitionDuration` for the **next** update only, then clears automatically. Use it to apply a single update without animation (or with a one-off custom duration) regardless of the configured value.
-
-* **`duration`** (Number, optional): Duration in milliseconds for the next transition cycle. `0` snaps (no animation); a positive value animates for that long; `undefined` falls back to `config.transitionDuration`.
-
-The override applies to the whole next update — every setter you call before the next `render()` — and wins even while another transition is still playing. It's the usual way to **compact** a graph that uses `NaN`-position removal: drop the absent slots and renumber without re-animating, so the surviving points (already at their coordinates) show no movement.
+Passing `0` is the usual way to **compact** a graph that uses `NaN`-position removal: drop the absent slots and renumber without re-animating, so the surviving points (already at their coordinates) show no movement.
 
 **Example:**
 ```javascript
-graph.setNextTransitionDuration(0); // snap the next update only
 graph.setPointPositions(compactedPositions);
 graph.setPointColors(compactedColors);
-graph.render();
+graph.render(undefined, 0); // snap this update only
 ```
 
 ### <a name="zoom_to_point_by_index" href="#zoom_to_point_by_index">#</a> graph.<b>zoomToPointByIndex</b>(<i>index</i>, [<i>duration</i>], [<i>scale</i>], [<i>canZoomOut</i>], [<i>enableSimulation</i>])

--- a/src/stories/3. api-reference.mdx
+++ b/src/stories/3. api-reference.mdx
@@ -85,7 +85,7 @@ This method sets the positions of points in a cosmos.gl graph using the provided
 
 On the next `render()`, points animate from their previous positions to the new ones using `transitionDuration` and `transitionEasing`. The first render after initialization always snaps (there is no prior state to animate from). See [Transitions](../?path=/docs/configuration--docs#transitions) in the configuration docs.
 
-**Removing and adding points without an index shuffle.** A point whose position is `NaN` is treated as **absent**: it fades out in place while every other point keeps its index and on-screen position (no array compaction, no slide). Set a point to `NaN` to remove it, and back to a real position to add one — both animate:
+**Removing and adding points without an index shuffle.** A point whose position is `NaN` (either coordinate) is treated as **absent**: it fades out in place while every other point keeps its index and on-screen position (no array compaction, no slide). Set a point to `NaN` to remove it, and back to a real position to add one — both animate:
 
 ```javascript
 // remove point i: it fades out, the rest hold still

--- a/src/stories/3. api-reference.mdx
+++ b/src/stories/3. api-reference.mdx
@@ -85,6 +85,17 @@ This method sets the positions of points in a cosmos.gl graph using the provided
 
 On the next `render()`, points animate from their previous positions to the new ones using `transitionDuration` and `transitionEasing`. The first render after initialization always snaps (there is no prior state to animate from). See [Transitions](../?path=/docs/configuration--docs#transitions) in the configuration docs.
 
+**Removing and adding points without an index shuffle.** A point whose position is `NaN` is treated as **absent**: it fades out in place while every other point keeps its index and on-screen position (no array compaction, no slide). Set a point to `NaN` to remove it, and back to a real position to add one — both animate:
+
+```javascript
+// remove point i: it fades out, the rest hold still
+positions[i * 2] = NaN;
+positions[i * 2 + 1] = NaN;
+graph.setPointPositions(positions);
+```
+
+By default an absent point fades to nothing (size and opacity → 0). To customize the exit look, pass per-point values via `setPointSizes` / `setPointColors` (e.g. recolor while fading); a `NaN` entry in those arrays means "use the exit default" for an absent point. This works with the simulation on or off — a `NaN` position is excluded from the force layout rather than corrupting it. Adding a point is the mirror (`NaN → real`, fades in). cosmos.gl does not auto-compact away the gaps — drop them yourself when convenient and snap the renumber with [`setNextTransitionDuration(0)`](#set_next_transition_duration). See the **Examples / Beginners → Add & Remove Points** story.
+
 **Example:**
 ```javascript
 graph.setPointPositions(new Float32Array([1, 2, 3, 4, 5, 6]));
@@ -398,6 +409,22 @@ The `render` method renders the graph and starts rendering. It does NOT modify s
   - If `undefined`: Keeps current alpha value.
 
 **Transitions:** If any setter (`setPointPositions`, `setPointColors`, `setPointSizes`, `setLinkColors`, `setLinkWidths`) has queued changes and `transitionDuration > 0`, `render()` starts an animated transition. When the simulation is running, only **position** transitions auto-pause it (and `onSimulationPause` fires), and the simulation stays paused afterwards until `unpause()` is called. The first render after initialization always snaps position changes — there is no prior state to animate from. See [Transitions](../?path=/docs/configuration--docs#transitions) in the configuration docs.
+
+### <a name="set_next_transition_duration" href="#set_next_transition_duration">#</a> graph.<b>setNextTransitionDuration</b>([<i>duration</i>])
+
+Overrides `config.transitionDuration` for the **next** update only, then clears automatically. Use it to apply a single update without animation (or with a one-off custom duration) regardless of the configured value.
+
+* **`duration`** (Number, optional): Duration in milliseconds for the next transition cycle. `0` snaps (no animation); a positive value animates for that long; `undefined` falls back to `config.transitionDuration`.
+
+The override applies to the whole next update — every setter you call before the next `render()` — and wins even while another transition is still playing. It's the usual way to **compact** a graph that uses `NaN`-position removal: drop the absent slots and renumber without re-animating, so the surviving points (already at their coordinates) show no movement.
+
+**Example:**
+```javascript
+graph.setNextTransitionDuration(0); // snap the next update only
+graph.setPointPositions(compactedPositions);
+graph.setPointColors(compactedColors);
+graph.render();
+```
 
 ### <a name="zoom_to_point_by_index" href="#zoom_to_point_by_index">#</a> graph.<b>zoomToPointByIndex</b>(<i>index</i>, [<i>duration</i>], [<i>scale</i>], [<i>canZoomOut</i>], [<i>enableSimulation</i>])
 

--- a/src/stories/beginners.stories.ts
+++ b/src/stories/beginners.stories.ts
@@ -6,6 +6,7 @@ import { quickStart } from './beginners/quick-start'
 import { actions } from './beginners/actions'
 import { pointLabels } from './beginners/point-labels'
 import { removePoints } from './beginners/remove-points'
+import { addRemovePoints } from './beginners/add-remove-points'
 import { linkHovering } from './beginners/link-hovering'
 import { linkSampling } from './beginners/link-sampling'
 import { pinnedPoints } from './beginners/pinned-points'
@@ -23,6 +24,9 @@ import removePointsStoryRaw from './beginners/remove-points/index?raw'
 import removePointsStoryCssRaw from './beginners/remove-points/style.css?raw'
 import removePointsStoryConfigRaw from './beginners/remove-points/config.ts?raw'
 import removePointsStoryDataGenRaw from './beginners/remove-points/data-gen.ts?raw'
+import addRemovePointsStoryRaw from './beginners/add-remove-points/index?raw'
+import addRemovePointsStoryConfigRaw from './beginners/add-remove-points/config.ts?raw'
+import addRemovePointsStoryCssRaw from './beginners/add-remove-points/style.css?raw'
 import linkHoveringStoryRaw from './beginners/link-hovering/index?raw'
 import linkHoveringStoryDataGenRaw from './beginners/link-hovering/data-generator.ts?raw'
 import linkHoveringStoryCssRaw from './beginners/link-hovering/style.css?raw'
@@ -120,6 +124,18 @@ export const RemovePoints: Story = {
       { name: 'config.ts', code: removePointsStoryConfigRaw },
       { name: 'data-gen.ts', code: removePointsStoryDataGenRaw },
       { name: 'style.css', code: removePointsStoryCssRaw },
+    ],
+  },
+}
+
+export const AddRemovePoints: Story = {
+  ...createStory(addRemovePoints),
+  name: 'Add & Remove Points',
+  parameters: {
+    sourceCode: [
+      { name: 'Story', code: addRemovePointsStoryRaw },
+      { name: 'config.ts', code: addRemovePointsStoryConfigRaw },
+      { name: 'style.css', code: addRemovePointsStoryCssRaw },
     ],
   },
 }

--- a/src/stories/beginners/add-remove-points/config.ts
+++ b/src/stories/beginners/add-remove-points/config.ts
@@ -1,0 +1,23 @@
+import { type GraphConfig } from '@cosmos.gl/graph'
+
+export const config: GraphConfig = {
+  spaceSize: 4096,
+  // Points keep the exact positions we set — no simulation, no auto-rescale — so a
+  // point appears exactly where you click and the others never move.
+  enableSimulation: false,
+  rescalePositions: false,
+  transitionDuration: 600,
+  backgroundColor: '#2d313a',
+  pointDefaultSize: 40,
+  pointDefaultColor: '#4B5BBF',
+  // Keep points a constant on-screen size regardless of zoom, so they stay clearly
+  // visible in this interactive demo.
+  scalePointsOnZoom: false,
+  // Ring under the cursor shows which point a click will remove.
+  hoveredPointCursor: 'pointer',
+  renderHoveredPointRing: true,
+  hoveredPointRingColor: '#ffffff',
+  fitViewOnInit: true,
+  fitViewPadding: 0.4,
+  attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmosgl-attribution-color);" target="_blank">Cosmograph</a>',
+}

--- a/src/stories/beginners/add-remove-points/config.ts
+++ b/src/stories/beginners/add-remove-points/config.ts
@@ -10,6 +10,10 @@ export const config: GraphConfig = {
   backgroundColor: '#2d313a',
   pointDefaultSize: 40,
   pointDefaultColor: '#4B5BBF',
+  // Links show what happens to a removed point's edges: the engine fades them out
+  // with the point (no need to drop them from the array before compacting).
+  linkDefaultWidth: 2,
+  linkDefaultColor: '#8890b0',
   // Keep points a constant on-screen size regardless of zoom, so they stay clearly
   // visible in this interactive demo.
   scalePointsOnZoom: false,

--- a/src/stories/beginners/add-remove-points/index.ts
+++ b/src/stories/beginners/add-remove-points/index.ts
@@ -99,12 +99,12 @@ export const addRemovePoints = (): { graph: Graph; div: HTMLDivElement; destroy?
     `
   }
 
-  /* ~ Push state to the engine ~ */
-  function update (): void {
+  /* ~ Push state to the engine. Pass transitionDuration = 0 to snap (no animation). ~ */
+  function update (transitionDuration?: number): void {
     graph.setPointPositions(new Float32Array(pointPositions))
     graph.setPointColors(new Float32Array(pointColors))
     graph.setPointSizes(new Float32Array(pointSizes))
-    graph.render()
+    graph.render(undefined, transitionDuration)
     renderSlots()
   }
 
@@ -164,10 +164,9 @@ export const addRemovePoints = (): { graph: Graph; div: HTMLDivElement; destroy?
       pointColors[slot * 4 + 1] = 0
       pointColors[slot * 4 + 2] = 0
       pointColors[slot * 4 + 3] = NaN // recolor to red while fading out
-    } else { // 'instant'
-      graph.setNextTransitionDuration(0) // snap — no fade
     }
-    update()
+    // 'instant' needs no channel changes — the render below snaps it with duration 0.
+    update(effect === 'instant' ? 0 : undefined)
   }
 
   /* ~ Compact: drop tombstones and renumber, snapped so nothing visibly moves ~ */
@@ -178,8 +177,7 @@ export const addRemovePoints = (): { graph: Graph; div: HTMLDivElement; destroy?
     pointColors = active.flatMap((slot) => pointColors.slice(slot * 4, slot * 4 + 4))
     pointSizes = active.map((slot) => pointSizes[slot])
     pointIds = active.map((slot) => pointIds[slot])
-    graph.setNextTransitionDuration(0)
-    update()
+    update(0) // snap the renumber so nothing visibly moves
   }
 
   /* ~ Seed a few points so there's something to interact with ~ */
@@ -196,8 +194,7 @@ export const addRemovePoints = (): { graph: Graph; div: HTMLDivElement; destroy?
       pointSizes.push(BASE_SIZE)
       pointIds.push(nextPointId++)
     }
-    graph.setNextTransitionDuration(0)
-    update()
+    update(0) // seed with no animation
     graph.fitView(0, config.fitViewPadding)
   }
 

--- a/src/stories/beginners/add-remove-points/index.ts
+++ b/src/stories/beginners/add-remove-points/index.ts
@@ -61,6 +61,10 @@ export const addRemovePoints = (): { graph: Graph; div: HTMLDivElement; destroy?
   let pointColors: number[] = []
   let pointSizes: number[] = []
   let pointIds: number[] = []
+  // Links as pairs of slot indices. Links to a removed (NaN) point stay in the array
+  // on purpose: the engine fades them out with the point and keeps them out of
+  // physics and picking. Compact drops them together with the tombstoned slots.
+  let links: number[] = []
   let nextPointId = 0
   let effect: Effect = 'grow'
 
@@ -104,8 +108,25 @@ export const addRemovePoints = (): { graph: Graph; div: HTMLDivElement; destroy?
     graph.setPointPositions(new Float32Array(pointPositions))
     graph.setPointColors(new Float32Array(pointColors))
     graph.setPointSizes(new Float32Array(pointSizes))
+    graph.setLinks(new Float32Array(links))
     graph.render(undefined, transitionDuration)
     renderSlots()
+  }
+
+  /* ~ Nearest active slot to (x, y) — a new point gets linked to it ~ */
+  function nearestActiveSlot (x: number, y: number): number | undefined {
+    let nearest: number | undefined
+    let nearestDistance = Infinity
+    for (const slot of activeSlots()) {
+      const dx = (pointPositions[slot * 2] as number) - x
+      const dy = (pointPositions[slot * 2 + 1] as number) - y
+      const distance = dx * dx + dy * dy
+      if (distance < nearestDistance) {
+        nearestDistance = distance
+        nearest = slot
+      }
+    }
+    return nearest
   }
 
   /* ~ Add a point at (x, y), fading in per the current effect ~ */
@@ -113,6 +134,9 @@ export const addRemovePoints = (): { graph: Graph; div: HTMLDivElement; destroy?
     const slot = slotCount()
     const [r, g, b] = randomColor()
     pointIds.push(nextPointId++)
+    // Link the new point to its nearest neighbor. The link fades in with the point.
+    const neighbor = nearestActiveSlot(x, y)
+    if (neighbor !== undefined) links.push(neighbor, slot)
 
     if (effect === 'instant') {
       // Single-phase: a new slot appears at its values immediately (no animation).
@@ -166,6 +190,7 @@ export const addRemovePoints = (): { graph: Graph; div: HTMLDivElement; destroy?
       pointColors[slot * 4 + 3] = NaN // recolor to red while fading out
     }
     // 'instant' needs no channel changes — the render below snaps it with duration 0.
+    // Links to this point are left in the array: the engine fades them out with it.
     update(effect === 'instant' ? 0 : undefined)
   }
 
@@ -173,6 +198,16 @@ export const addRemovePoints = (): { graph: Graph; div: HTMLDivElement; destroy?
   function compact (): void {
     const active = activeSlots()
     if (active.length === slotCount()) return
+    // Renumbering invalidates slot indices, so links must be remapped too — and links
+    // to tombstoned slots are dropped for real here.
+    const oldToNew = new Map(active.map((slot, newSlot) => [slot, newSlot]))
+    const remappedLinks: number[] = []
+    for (let i = 0; i < links.length; i += 2) {
+      const source = oldToNew.get(links[i] as number)
+      const target = oldToNew.get(links[i + 1] as number)
+      if (source !== undefined && target !== undefined) remappedLinks.push(source, target)
+    }
+    links = remappedLinks
     pointPositions = active.flatMap((slot) => [pointPositions[slot * 2], pointPositions[slot * 2 + 1]])
     pointColors = active.flatMap((slot) => pointColors.slice(slot * 4, slot * 4 + 4))
     pointSizes = active.map((slot) => pointSizes[slot])
@@ -186,6 +221,7 @@ export const addRemovePoints = (): { graph: Graph; div: HTMLDivElement; destroy?
     pointColors = []
     pointSizes = []
     pointIds = []
+    links = []
     nextPointId = 0
     for (let i = 0; i < 6; i += 1) {
       const angle = (i / 6) * Math.PI * 2
@@ -193,6 +229,7 @@ export const addRemovePoints = (): { graph: Graph; div: HTMLDivElement; destroy?
       pointColors.push(...randomColor())
       pointSizes.push(BASE_SIZE)
       pointIds.push(nextPointId++)
+      links.push(i, (i + 1) % 6) // ring of links between the seed points
     }
     update(0) // seed with no animation
     graph.fitView(0, config.fitViewPadding)

--- a/src/stories/beginners/add-remove-points/index.ts
+++ b/src/stories/beginners/add-remove-points/index.ts
@@ -1,0 +1,264 @@
+import { Graph } from '@cosmos.gl/graph'
+import { config } from './config'
+import './style.css'
+
+const SPACE_CENTER = 4096 / 2
+const BASE_SIZE = 40
+
+// A random vivid color as a normalized RGBA tuple (0..1), as the engine expects.
+function randomColor (): [number, number, number, number] {
+  const hue = Math.random()
+  const k = (n: number): number => (n + hue * 6) % 6
+  const f = (n: number): number => 1 - Math.max(0, Math.min(k(n), 4 - k(n), 1)) * 0.5
+  return [f(5), f(3), f(1), 1]
+}
+
+// The fade effect applied to both adding (NaN → real) and removing (real → NaN):
+// - 'grow':    grow/shrink + fade        (size & alpha animate 0 ↔ real)
+// - 'opacity': fade at full size         (alpha animates 0 ↔ real, size kept)
+// - 'recolor': green in / red out        (custom color while fading)
+// - 'instant': no animation              (snap in / out)
+type Effect = 'grow' | 'opacity' | 'recolor' | 'instant'
+
+const EFFECTS: { id: Effect; label: string }[] = [
+  { id: 'grow', label: 'grow + fade' },
+  { id: 'opacity', label: 'opacity' },
+  { id: 'recolor', label: 'recolor' },
+  { id: 'instant', label: 'instant' },
+]
+
+export const addRemovePoints = (): { graph: Graph; div: HTMLDivElement; destroy?: () => void } => {
+  const div = document.createElement('div')
+  div.className = 'add-remove-points'
+
+  const graphDiv = document.createElement('div')
+  graphDiv.className = 'graph'
+  div.appendChild(graphDiv)
+
+  const controlsDiv = document.createElement('div')
+  controlsDiv.className = 'controls'
+  div.appendChild(controlsDiv)
+
+  // Bottom panel: the array drawn as a strip of slots, plus the instruction line.
+  const panelDiv = document.createElement('div')
+  panelDiv.className = 'panel'
+  div.appendChild(panelDiv)
+
+  const slotsDiv = document.createElement('div')
+  slotsDiv.className = 'slots'
+  panelDiv.appendChild(slotsDiv)
+
+  const hintDiv = document.createElement('div')
+  hintDiv.className = 'hint'
+  panelDiv.appendChild(hintDiv)
+
+  // ── Slot-based state with NaN tombstones ───────────────────────────────────
+  // A point's array index is its *stable slot*. Removing a point sets its position
+  // to NaN (a tombstone) instead of compacting the array, so every other point
+  // keeps its index and on-screen position. Adding is the mirror: NaN → a real
+  // position. Both animate per the selected effect.
+  let pointPositions: number[] = []
+  let pointColors: number[] = []
+  let pointSizes: number[] = []
+  let pointIds: number[] = []
+  let nextPointId = 0
+  let effect: Effect = 'grow'
+
+  /* ~ Slot helpers ~ */
+  const slotCount = (): number => pointPositions.length / 2 // active + tombstoned
+  const isActive = (slot: number): boolean => !Number.isNaN(pointPositions[slot * 2])
+  const activeSlots = (): number[] => {
+    const result: number[] = []
+    for (let i = 0; i < slotCount(); i += 1) if (isActive(i)) result.push(i)
+    return result
+  }
+
+  // Draw the array as a strip of cells in index order — one per slot. An active
+  // slot is filled with its point's color and shows its index; a removed slot is a
+  // dashed "tombstone" that stays in place (its index is preserved). This makes the
+  // model visible: removal leaves a hole, and Compact re-packs + renumbers.
+  function renderSlots (): void {
+    const total = slotCount()
+
+    const cells: string[] = []
+    for (let slot = 0; slot < total; slot += 1) {
+      if (isActive(slot)) {
+        const r = Math.round((pointColors[slot * 4] ?? 0) * 255)
+        const g = Math.round((pointColors[slot * 4 + 1] ?? 0) * 255)
+        const b = Math.round((pointColors[slot * 4 + 2] ?? 0) * 255)
+        cells.push(`<div class="slot" style="background: rgb(${r}, ${g}, ${b})">${slot}</div>`)
+      } else {
+        // A faded-out slot is literally NaN in the positions array.
+        cells.push('<div class="slot empty">NaN</div>')
+      }
+    }
+
+    slotsDiv.innerHTML = `
+      <div class="slots-title">the array you pass to <code>setPointPositions</code></div>
+      <div class="slots-strip">${cells.join('') || '<span class="slots-empty">empty array</span>'}</div>
+    `
+  }
+
+  /* ~ Push state to the engine ~ */
+  function update (): void {
+    graph.setPointPositions(new Float32Array(pointPositions))
+    graph.setPointColors(new Float32Array(pointColors))
+    graph.setPointSizes(new Float32Array(pointSizes))
+    graph.render()
+    renderSlots()
+  }
+
+  /* ~ Add a point at (x, y), fading in per the current effect ~ */
+  function addPointAt (x: number, y: number): void {
+    const slot = slotCount()
+    const [r, g, b] = randomColor()
+    pointIds.push(nextPointId++)
+
+    if (effect === 'instant') {
+      // Single-phase: a new slot appears at its values immediately (no animation).
+      pointPositions.push(x, y)
+      pointColors.push(r, g, b, 1)
+      pointSizes.push(BASE_SIZE)
+      update()
+      return
+    }
+
+    // Two-phase: commit the slot as absent with the effect's *start* look, then set
+    // its real values so the size/color transition animates start → real (fade in).
+    pointPositions.push(NaN, NaN)
+    if (effect === 'grow') {
+      pointSizes.push(NaN) // size 0 → grows in
+      pointColors.push(r, g, b, NaN) // alpha 0 → fades in
+    } else if (effect === 'opacity') {
+      pointSizes.push(BASE_SIZE) // full size from the start
+      pointColors.push(r, g, b, NaN) // alpha 0 → fades in
+    } else { // 'recolor'
+      pointSizes.push(BASE_SIZE)
+      pointColors.push(0, 1, 0, NaN) // starts green, fades in
+    }
+    update() // commit the start state
+
+    pointPositions[slot * 2] = x
+    pointPositions[slot * 2 + 1] = y
+    pointSizes[slot] = BASE_SIZE
+    pointColors[slot * 4] = r
+    pointColors[slot * 4 + 1] = g
+    pointColors[slot * 4 + 2] = b
+    pointColors[slot * 4 + 3] = 1
+    update() // animate to the real values
+  }
+
+  /* ~ Remove a point, fading out per the current effect ~ */
+  function removeSlot (slot: number): void {
+    if (!isActive(slot)) return
+    pointPositions[slot * 2] = NaN
+    pointPositions[slot * 2 + 1] = NaN
+
+    if (effect === 'grow') {
+      pointSizes[slot] = NaN // → exit default 0 (shrinks out)
+      pointColors[slot * 4 + 3] = NaN // → exit default 0 (fades out)
+    } else if (effect === 'opacity') {
+      pointColors[slot * 4 + 3] = NaN // fade out, keep the size
+    } else if (effect === 'recolor') {
+      pointColors[slot * 4] = 1
+      pointColors[slot * 4 + 1] = 0
+      pointColors[slot * 4 + 2] = 0
+      pointColors[slot * 4 + 3] = NaN // recolor to red while fading out
+    } else { // 'instant'
+      graph.setNextTransitionDuration(0) // snap — no fade
+    }
+    update()
+  }
+
+  /* ~ Compact: drop tombstones and renumber, snapped so nothing visibly moves ~ */
+  function compact (): void {
+    const active = activeSlots()
+    if (active.length === slotCount()) return
+    pointPositions = active.flatMap((slot) => [pointPositions[slot * 2], pointPositions[slot * 2 + 1]])
+    pointColors = active.flatMap((slot) => pointColors.slice(slot * 4, slot * 4 + 4))
+    pointSizes = active.map((slot) => pointSizes[slot])
+    pointIds = active.map((slot) => pointIds[slot])
+    graph.setNextTransitionDuration(0)
+    update()
+  }
+
+  /* ~ Seed a few points so there's something to interact with ~ */
+  function reset (): void {
+    pointPositions = []
+    pointColors = []
+    pointSizes = []
+    pointIds = []
+    nextPointId = 0
+    for (let i = 0; i < 6; i += 1) {
+      const angle = (i / 6) * Math.PI * 2
+      pointPositions.push(SPACE_CENTER + Math.cos(angle) * 500, SPACE_CENTER + Math.sin(angle) * 500)
+      pointColors.push(...randomColor())
+      pointSizes.push(BASE_SIZE)
+      pointIds.push(nextPointId++)
+    }
+    graph.setNextTransitionDuration(0)
+    update()
+    graph.fitView(0, config.fitViewPadding)
+  }
+
+  /* ~ UI ~ */
+  function renderHint (): void {
+    const name = EFFECTS.find((e) => e.id === effect)?.label ?? ''
+    hintDiv.innerHTML = `<b>Click empty space</b> to add · <b>click a point</b> to remove<span class="effect">effect: ${name}</span>`
+  }
+
+  function renderControls (): void {
+    controlsDiv.innerHTML = ''
+
+    const picker = document.createElement('div')
+    picker.className = 'picker'
+    for (const e of EFFECTS) {
+      const chip = document.createElement('div')
+      chip.className = e.id === effect ? 'chip active' : 'chip'
+      chip.textContent = e.label
+      chip.addEventListener('click', () => {
+        effect = e.id
+        renderControls()
+        renderHint()
+      })
+      picker.appendChild(chip)
+    }
+    controlsDiv.appendChild(picker)
+
+    const buttons = document.createElement('div')
+    buttons.className = 'buttons'
+    for (const [label, onClick] of [['Compact', compact], ['Reset', reset]] as const) {
+      const button = document.createElement('div')
+      button.className = 'action'
+      button.textContent = label
+      button.addEventListener('click', onClick)
+      buttons.appendChild(button)
+    }
+    controlsDiv.appendChild(buttons)
+  }
+
+  // Defined after the functions above so `onClick` can call them (the functions
+  // reference `graph` back — allowed: they only run after this assignment).
+  const graph = new Graph(graphDiv, {
+    ...config,
+    // Click a point to remove it; click empty space to add one there.
+    onClick: (index, _pointPosition, event): void => {
+      if (index !== undefined && isActive(index)) {
+        removeSlot(index)
+      } else {
+        const [x, y] = graph.screenToSpacePosition([event.offsetX, event.offsetY])
+        addPointAt(x, y)
+      }
+    },
+  })
+
+  renderControls()
+  renderHint()
+  reset()
+
+  const destroy = (): void => {
+    graph.destroy()
+  }
+
+  return { div, graph, destroy }
+}

--- a/src/stories/beginners/add-remove-points/style.css
+++ b/src/stories/beginners/add-remove-points/style.css
@@ -1,0 +1,173 @@
+/* All rules are scoped under `.add-remove-points` so this story's generic class
+   names (action, graph, panel, …) don't leak into — or get overridden by — other
+   stories' globally-loaded CSS. */
+
+.add-remove-points {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  font-family: "Nunito Sans", -apple-system, ".SFNSText-Regular", "San Francisco", BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.add-remove-points .graph {
+  width: 100%;
+  height: 100vh;
+}
+
+/* Effect picker + buttons, top-left. */
+.add-remove-points .controls {
+  position: absolute;
+  top: 14px;
+  left: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.add-remove-points .picker {
+  display: flex;
+  gap: 6px;
+}
+
+.add-remove-points .chip {
+  font-size: 10pt;
+  padding: 5px 12px;
+  color: #c7cddb;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.add-remove-points .chip:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.add-remove-points .chip.active {
+  color: #1b1f27;
+  background: #e7ecff;
+  border-color: #e7ecff;
+  font-weight: 700;
+}
+
+.add-remove-points .buttons {
+  display: flex;
+  gap: 6px;
+}
+
+.add-remove-points .action {
+  font-size: 9.5pt;
+  padding: 4px 11px;
+  color: #aeb6cc;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 5px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.add-remove-points .action:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+/* Bottom panel: slot strip + instruction line. */
+.add-remove-points .panel {
+  position: absolute;
+  bottom: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  max-width: 90%;
+  padding: 12px 16px;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  user-select: none;
+}
+
+/* The array drawn as a strip of slots. */
+.add-remove-points .slots {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 7px;
+}
+
+.add-remove-points .slots-title {
+  font-size: 9.5pt;
+  color: #aeb6cc;
+}
+
+.add-remove-points .slots-title b {
+  color: #fff;
+}
+
+.add-remove-points .slots-title code {
+  font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+  font-size: 9pt;
+  color: #e7ecff;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+.add-remove-points .slots-strip {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+  max-width: 70vw;
+  max-height: 22vh;
+  overflow-y: auto;
+}
+
+.add-remove-points .slot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  font-size: 9pt;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
+}
+
+/* Faded-out slot — kept in place, holds NaN in the array. */
+.add-remove-points .slot.empty {
+  background: transparent;
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+  color: #6b7280;
+  font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+  font-size: 7.5pt;
+  font-weight: 400;
+  text-shadow: none;
+}
+
+.add-remove-points .slots-empty {
+  font-size: 9.5pt;
+  color: #6b7280;
+}
+
+/* Instruction line. */
+.add-remove-points .hint {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 10pt;
+  color: #c7cddb;
+  white-space: nowrap;
+}
+
+.add-remove-points .hint b {
+  color: #fff;
+}
+
+.add-remove-points .hint .effect {
+  color: #8b93a7;
+}

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -147,3 +147,11 @@ export const defaultConfigValues = {
 // Internal constants (not part of GraphConfigInterface)
 export const hoveredPointRingOpacity = 0.7
 export const focusedPointRingOpacity = 0.95
+
+/**
+ * What a `NaN` size/color channel of an **absent** (removed) point resolves to:
+ * fade to nothing. The single source for both resolution sites — the CPU mirrors
+ * (`GraphData.getResolvedPoint*`) and the draw shader (injected as `#define`s).
+ */
+export const EXIT_DEFAULT_SIZE = 0
+export const EXIT_DEFAULT_COLOR_CHANNEL = 0


### PR DESCRIPTION
Removing a point meant shrinking the positions array — which renumbers every point after it, so the whole graph slides over to fill the gap. Taking one point out made everything jump.

Now a point can leave on its own: set its position to `NaN` and it **fades out in place**, while every other point keeps its index and spot. Giving the slot a real position fades it back in.

https://github.com/user-attachments/assets/02ba20d1-da81-46bc-8254-53a140955fd8

```ts
// remove point i — it fades out, everything else stays put
positions[i * 2] = NaN
positions[i * 2 + 1] = NaN
graph.setPointPositions(positions)
```

- **The fade is automatic** — or pass per-point sizes/colors in the same update to shrink, fade, or recolor a point as it leaves. Hover picking keeps working while a bare removal fades.
- **Links follow their points** — they fade out with a removed endpoint and stop being hoverable; drop them whenever you compact.
- **Absent points are really gone** — excluded from all forces (safe with the simulation on or off), from hover, selection, sampling, and zoom/`fitView`.
- **Your arrays stay yours** — size/color arrays are read as-is and never modified (`NaN` channels resolve at render time), and read-backs are honest: absent points come back as `NaN` (`getTrackedPointPositionsMap` omits them), `getPointColors`/`getPointSizes` return as-rendered snapshots.
- **Opt-in and non-breaking** — no API signatures changed; shrinking the array still works exactly as before. cosmos.gl does not auto-compact the gaps; reuse freed slots or compact when convenient.

Also adds an optional duration to **`render(simulationAlpha?, transitionDuration?)`** — for the transition this render starts, this call only. `0` snaps, `undefined` uses `config.transitionDuration`. Made for compaction: drop the tombstones, renumber, and snap so nothing visibly moves — `graph.render(undefined, 0)`. A transition already playing keeps its own duration (config changes apply from the next one).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an “Add & Remove Points” beginner demo using opt-in stable slots via `NaN` tombstones, with customizable exit fade styling.
  - Extended `graph.render(simulationAlpha?, transitionDuration?)` to support a per-call transition duration override.

- **Bug Fixes**
  - Improved handling of removed/absent points across rendering, picking/hover, curves/links, and force/physics to prevent `NaN` contamination and keep transitions consistent.

- **Documentation**
  - Updated API docs for absent `NaN` semantics, exit-default color/size resolution, and the `render(undefined, 0)` snap workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->