### PR TITLE
On-demand rendering: only draw frames when something can change

### DIFF
--- a/history/2026/2026-07-07-on-demand-rendering.md
+++ b/history/2026/2026-07-07-on-demand-rendering.md
@@ -1,0 +1,83 @@
+<!-- suggested path: history/2026/2026-07-07-on-demand-rendering.md -->
+# On-demand rendering
+
+**Date:** 2026-07-07
+**Commits:** `2b6629d`
+
+## Why
+
+cosmos.gl rendered on every `requestAnimationFrame`, forever — `frame()` unconditionally
+re-scheduled itself even after the simulation ended and nothing on screen could change.
+An idle graph kept the GPU busy and drained battery on pages that embed a visualization
+and then just sit there. Rendering now happens only when something visual can actually
+change; a static scene costs zero work per frame.
+
+## What changed
+
+All in `src/index.ts` — the Zoom, Drag, and Transition modules are untouched.
+
+`frame()` is now an idempotent scheduler: it schedules a single RAF (no-op if one is
+already pending), and the callback re-schedules only while `shouldKeepRendering()` is
+true. A new private `requestRender()` is the funnel every visual-state event goes
+through. `startFrames()` is gone; `stopFrames()` remains for `destroy()` and the
+empty-data `render()` path.
+
+### When the loop keeps running (`shouldKeepRendering()`)
+
+| Condition | Why it needs continuous frames |
+|---|---|
+| `fpsMonitor` exists (`showFPSMonitor: true`) | gl-bench derives FPS from frame cadence; also doubles as a debug escape hatch |
+| `store.isSimulationRunning` | forces step every tick (alpha floor still handled by `end()`) |
+| `transition.isActive` | GPU interpolation advances per frame (`isPending` deliberately does *not* count — a queued-but-never-rendered transition must not keep the loop alive) |
+| `dragInstance.isActive` | drag shader writes positions per frame |
+| `zoomInstance.isRunning` | user gesture or programmatic d3 zoom transition in flight |
+| `isRightClickMouse && enableRightClickRepulsion` | mouse repulsion runs **regardless of** `isSimulationRunning` in `runSimulationStep` |
+| `hasPendingHoverWork()` | see hover throttle note below |
+
+### One-shot render triggers (`requestRender()` call sites)
+
+Pointer enter/move/leave/down (and the touch long-press re-pick), all three zoom and
+drag `.detect` handlers, `setConfig`/`setConfigPartial` (one unconditional call at the
+end of `updateStateFromConfig` — it applies colors/sizes/status/spaceSize/pixelRatio
+immediately), `start()`/`unpause()`/`step()`, public `create()` (its contract is
+"apply data without `render()`"), `setImageData`, `setPinnedPoints`, and `render()`
+itself. `pause()`/`stop()` need no hook: the simulation step runs *before* the draw
+within a frame, so the last state is always already drawn.
+
+Programmatic zoom (`setZoomLevel`, `zoomToPointByIndex`, `fitView*`,
+`setZoomTransformByPointPositions`) needs no duration bookkeeping — d3 transitions run
+on d3's own timer and emit a `zoom` event every frame (synchronously for
+`duration = 0`), and each event schedules a render.
+
+## Details worth knowing
+
+- **Canvas resize while idle.** `resizeCanvas()` used to detect CSS size changes by
+  per-frame polling. A `ResizeObserver` on the canvas now schedules a redraw; the
+  actual size/zoom-transform work still happens in the in-frame `resizeCanvas()`.
+  Disconnected in `destroy()`.
+- **Drag release needs one extra frame.** The drag GPU write happens *after* the draw
+  pass in `renderFrame`, so the final drag position only becomes visible on the next
+  frame — the drag `end.detect` hook schedules it. Without this, a released point
+  snaps back visually by one frame's worth of movement.
+- **Hover throttle vs. loop shutdown.** `findHoveredItem()` runs at most every 4
+  frames and skips sub-2px movement. `hasPendingHoverWork()` keeps the loop alive
+  (max ~5 frames) until detection actually executes — which updates the last-checked
+  mouse position and consumes `_shouldForceHoverDetection`, turning the predicate
+  false. Hover latency is identical to before; the loop just stops afterwards.
+- **Stale-buffer guard.** `render()` with empty data stops frames but doesn't clear
+  `pointsTextureSize`. `frame()` therefore refuses to schedule when
+  `pointsNumber`/`linksNumber` are both zero, so a later pointermove can't resurrect
+  drawing of stale GPU buffers.
+- **External-device integrations** that relied on cosmos.gl redrawing the shared
+  context every frame no longer get that for free — trigger a cosmos.gl-observable
+  change (e.g. `render()`) when a redraw is needed.
+
+## Example
+
+`src/stories/experiments/on-demand-rendering.ts` (*Examples/Misc → On Demand
+Rendering*): a mesh graph with a frame-counter overlay (patched
+`requestAnimationFrame`, updated on a `setInterval` so it keeps reporting while cosmos
+renders nothing). Watch the counter hit "idle" after the simulation decays, and resume
+on hover, zoom, drag, or window resize. The story overrides `simulationDecay` — the
+shared story config uses a decay so large the simulation would render practically
+forever.

--- a/history/2026/2026-07-07-on-demand-rendering.md
+++ b/history/2026/2026-07-07-on-demand-rendering.md
@@ -2,7 +2,7 @@
 # On-demand rendering
 
 **Date:** 2026-07-07
-**Commits:** `2b6629d`
+**Commits:** `On-demand rendering` (`403e0ba`); post-review: `refactor(render): observer-driven screen-size sync; rename resizeCanvas to syncScreenSize` (`a2ab764`), `fix(render): keep the loop running when ResizeObserver is unavailable` (`13e11e6`)
 
 ## Why
 
@@ -26,6 +26,7 @@ empty-data `render()` path.
 
 | Condition | Why it needs continuous frames |
 |---|---|
+| no `ResizeObserver` in the environment (jsdom, legacy embeds) | nothing can wake the loop on a resize, so it never idles — the per-frame size check then works exactly like before on-demand rendering |
 | `fpsMonitor` exists (`showFPSMonitor: true`) | gl-bench derives FPS from frame cadence; also doubles as a debug escape hatch |
 | `store.isSimulationRunning` | forces step every tick (alpha floor still handled by `end()`) |
 | `transition.isActive` | GPU interpolation advances per frame (`isPending` deliberately does *not* count — a queued-but-never-rendered transition must not keep the loop alive) |
@@ -51,10 +52,13 @@ on d3's own timer and emit a `zoom` event every frame (synchronously for
 
 ## Details worth knowing
 
-- **Canvas resize while idle.** `resizeCanvas()` used to detect CSS size changes by
-  per-frame polling. A `ResizeObserver` on the canvas now schedules a redraw; the
-  actual size/zoom-transform work still happens in the in-frame `resizeCanvas()`.
-  Disconnected in `destroy()`.
+- **Canvas resize while idle.** Size changes used to be detected by per-frame polling.
+  A `ResizeObserver` on the canvas now flags the change (`_shouldSyncScreenSize`) and
+  wakes the loop; the frame applies it via `syncScreenSize()` — renamed from
+  `resizeCanvas`, since it never touched `canvas.width/height` (luma.gl's autoResize
+  owns the drawing buffer). The per-frame `clientWidth` reads (forced-layout hazards)
+  are gone from the render path; environments without `ResizeObserver` keep the loop
+  running instead (see the table above). Disconnected in `destroy()`.
 - **Drag release needs one extra frame.** The drag GPU write happens *after* the draw
   pass in `renderFrame`, so the final drag position only becomes visible on the next
   frame — the drag `end.detect` hook schedules it. Without this, a released point
@@ -71,6 +75,16 @@ on d3's own timer and emit a `zoom` event every frame (synchronously for
 - **External-device integrations** that relied on cosmos.gl redrawing the shared
   context every frame no longer get that for free — trigger a cosmos.gl-observable
   change (e.g. `render()`) when a redraw is needed.
+
+## Post-review updates
+
+Rebased onto v3.3 main (one keep-both conflict: this PR's observer and the luma-9.3
+first-measurement await share the setup block) and reviewed with a deep multi-agent
+pass; its fixes are the post-review commits above. The `Examples/Experiments →
+Examples/Misc` story-group rename was kept as deliberate. Verified: the loop idles at
+a stable frame count, wakes on hover/zoom, re-idles; resize-while-idle costs exactly
+two frames; an exhaustive sweep of every pixel-mutating public API found no path that
+fails to schedule a frame.
 
 ## Example
 

--- a/history/PROMPT.md
+++ b/history/PROMPT.md
@@ -49,6 +49,11 @@ Use when recent commits extend or correct a topic that already has an entry — 
 ### Ground rules
 
 - Read 1–2 recent entries under `history/` before writing — the corpus is the real source of truth on tone and detail level.
+- **Cite commits as subject + hash**, e.g. `` `feat(links): add dashed link styles` (`b42d045`) `` — this repo
+  rebase/squash-merges, which rewrites hashes, so the subject line is the durable identifier
+  (recoverable via `git log --grep`); the hash is a convenience that may go stale. When updating an
+  entry whose hashes no longer exist, match commits by subject and refresh the hashes if convenient —
+  never treat a stale hash as a reason to drop the citation.
 - Don't invent facts. If something's missing or unclear, add `<!-- TODO: ... -->` instead of guessing.
 - Writing before merge? Leave the commit hash as `<!-- TODO -->` and fill it in after.
 - Output **only** the markdown content ready to save.

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,11 +50,14 @@ export class Graph {
   private shouldDestroyDevice: boolean
   private requestAnimationFrameId = 0
   /**
-   * With on-demand rendering nothing polls the canvas size while idle;
-   * this observer schedules a redraw on element resize. The actual
-   * screen-size/zoom-transform update stays in resizeCanvas() inside the frame.
+   * Detects canvas element resizes:
+   * resize → `_shouldSyncScreenSize` + `requestRender()` → `syncScreenSize()` next frame.
+   * The work always runs in-frame, so resizing behaves the same whether the
+   * loop was running or idle.
    */
   private resizeObserver: ResizeObserver | undefined
+  /** Set by the ResizeObserver; the next frame applies it via syncScreenSize(). */
+  private _shouldSyncScreenSize = false
   private isRightClickMouse = false
   /**
    * Touch/pen long-press timer. Set on pointerdown for non-mouse pointers and
@@ -209,11 +212,13 @@ export class Graph {
       ])
       if (this._isDestroyed) return device
 
-      // With on-demand rendering there is no per-frame resize polling, so a resize while
-      // the loop is idle must schedule a frame itself; the actual resize work still runs
-      // in-frame (resizeCanvas), and luma's own observer resizes the drawing buffer.
+      // Two observers watch this canvas: this one flags the screen-size sync and
+      // wakes the loop; luma's own resizes the drawing buffer.
       if (typeof ResizeObserver !== 'undefined') {
-        this.resizeObserver = new ResizeObserver(() => { this.requestRender() })
+        this.resizeObserver = new ResizeObserver(() => {
+          this._shouldSyncScreenSize = true
+          this.requestRender()
+        })
         this.resizeObserver.observe(this.canvas)
       }
 
@@ -1176,7 +1181,7 @@ export class Graph {
 
     // Override the config's `enableSimulationDuringZoom` for this programmatic zoom transition.
     this.zoomInstance.shouldEnableSimulationDuringZoomOverride = enableSimulation
-    this.resizeCanvas()
+    this.syncScreenSize()
     const transform = this.zoomInstance.getTransform(positions, scale, padding)
     this.canvasD3Selection
       ?.transition()
@@ -1791,7 +1796,7 @@ export class Graph {
     }
     if (prevConfig.spaceSize !== this.config.spaceSize) {
       this.store.adjustSpaceSize(this.config.spaceSize, this.device?.limits.maxTextureDimension2D ?? 4096)
-      this.resizeCanvas(true)
+      this.syncScreenSize(true)
       this.update(this.store.isSimulationRunning ? this.store.alpha : 0)
     }
     if (prevConfig.showFPSMonitor !== this.config.showFPSMonitor) {
@@ -2157,7 +2162,12 @@ export class Graph {
 
     const frameNow = now ?? performance.now()
     this.fpsMonitor?.begin()
-    this.resizeCanvas()
+    // Apply a screen-size change the observer flagged. Without a ResizeObserver
+    // (rare embeds, jsdom) fall back to checking every frame.
+    if (this._shouldSyncScreenSize || !this.resizeObserver) {
+      this._shouldSyncScreenSize = false
+      this.syncScreenSize()
+    }
 
     const shouldInterpolatePositions = this.transition.isActiveFor(TransitionProperty.Positions)
     const shouldAnimatePointColors = this.transition.isActiveFor(TransitionProperty.PointColors)
@@ -2333,20 +2343,30 @@ export class Graph {
     }
   }
 
-  private resizeCanvas (forceResize = false): void {
+  /**
+   * Updates cosmos state to match the canvas's CSS size:
+   * - `store.screenSize`
+   * - the zoom transform — re-centered so the view keeps looking at the same spot
+   * - the screen-sized sampling grids and picking FBOs
+   *
+   * Does NOT touch `canvas.width`/`canvas.height` — the drawing buffer belongs
+   * to luma.gl's autoResize.
+   *
+   * Skips the work when the CSS size is unchanged. Pass `force` when state must
+   * be rebuilt at the same size (e.g. `spaceSize` remaps the world).
+   */
+  private syncScreenSize (force = false): void {
     if (this._isDestroyed) return
     const w = this.canvas.clientWidth
     const h = this.canvas.clientHeight
     const [prevW, prevH] = this.store.screenSize
 
-    // Check if CSS size changed (luma.gl's autoResize handles canvas.width/height automatically)
-    if (forceResize || prevW !== w || prevH !== h) {
+    if (force || prevW !== w || prevH !== h) {
       const { k } = this.zoomInstance.eventTransform
       const centerPosition = this.zoomInstance.convertScreenToSpacePosition([prevW / 2, prevH / 2])
 
       this.store.updateScreenSize(w, h)
-      // Note: canvas.width and canvas.height are managed by luma.gl's autoResize
-      // We only update our internal state and dependent components
+      // canvas.width/height stay untouched — luma.gl's autoResize owns the drawing buffer
       this.canvasD3Selection
         ?.call(this.zoomInstance.behavior.transform, this.zoomInstance.getTransform(centerPosition, k))
       this.points?.updateSampledPointsGrid()

--- a/src/index.ts
+++ b/src/index.ts
@@ -2123,6 +2123,10 @@ export class Graph {
    * continuous activity can still change visual state.
    */
   private shouldKeepRendering (): boolean {
+    // No ResizeObserver (jsdom, legacy embeds): nothing can wake the loop on a
+    // resize, so keep it running — the per-frame size check in renderFrame then
+    // works exactly like it did before on-demand rendering.
+    if (!this.resizeObserver) return true
     // gl-bench derives FPS from frame cadence; keep the loop continuous while
     // the monitor is shown so its numbers stay meaningful.
     if (this.fpsMonitor) return true
@@ -2163,7 +2167,8 @@ export class Graph {
     const frameNow = now ?? performance.now()
     this.fpsMonitor?.begin()
     // Apply a screen-size change the observer flagged. Without a ResizeObserver
-    // (rare embeds, jsdom) fall back to checking every frame.
+    // the loop never idles (see shouldKeepRendering), so checking every frame
+    // here keeps resize detection working like before on-demand rendering.
     if (this._shouldSyncScreenSize || !this.resizeObserver) {
       this._shouldSyncScreenSize = false
       this.syncScreenSize()

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,12 @@ export class Graph {
    */
   private shouldDestroyDevice: boolean
   private requestAnimationFrameId = 0
+  /**
+   * With on-demand rendering nothing polls the canvas size while idle;
+   * this observer schedules a redraw on element resize. The actual
+   * screen-size/zoom-transform update stays in resizeCanvas() inside the frame.
+   */
+  private resizeObserver: ResizeObserver | undefined
   private isRightClickMouse = false
   /**
    * Touch/pen long-press timer. Set on pointerdown for non-mouse pointers and
@@ -203,6 +209,14 @@ export class Graph {
       ])
       if (this._isDestroyed) return device
 
+      // With on-demand rendering there is no per-frame resize polling, so a resize while
+      // the loop is idle must schedule a frame itself; the actual resize work still runs
+      // in-frame (resizeCanvas), and luma's own observer resizes the drawing buffer.
+      if (typeof ResizeObserver !== 'undefined') {
+        this.resizeObserver = new ResizeObserver(() => { this.requestRender() })
+        this.resizeObserver.observe(this.canvas)
+      }
+
       const w = this.canvas.clientWidth
       const h = this.canvas.clientHeight
 
@@ -218,6 +232,9 @@ export class Graph {
           this._isPointerOnCanvas = true
           this._lastMouseX = event.clientX
           this._lastMouseY = event.clientY
+          // Drain any hover work that accumulated while the pointer was away
+          // (forced hover check or unchecked mouse movement).
+          this.requestRender()
         })
         .on('pointermove.cosmos', (event: PointerEvent) => {
           if (!event.isPrimary) return
@@ -243,6 +260,8 @@ export class Graph {
             this.store.hoveredPoint?.position,
             this.currentEvent
           )
+
+          this.requestRender()
         })
         .on('pointerleave.cosmos pointercancel.cosmos', (event: PointerEvent) => {
           // Non-primary pointers (e.g. second finger of a pinch) leaving must not
@@ -275,6 +294,9 @@ export class Graph {
 
           // Update cursor style after clearing hover states
           this.updateCanvasCursor()
+
+          // Hover ring / link highlight was cleared — redraw without it
+          this.requestRender()
         })
         .on('pointerdown.cosmos', (event: PointerEvent) => {
           if (!event.isPrimary) return
@@ -288,6 +310,8 @@ export class Graph {
           this._lastMouseY = event.clientY
           this.updateMousePosition(event)
           this.findHoveredItem(true)
+          // The immediate pick may have shown/moved the hover ring
+          this.requestRender()
 
           // Touch/pen long-press → contextmenu. The mouse path already gets
           // contextmenu from the browser; this fills the gap for touch where
@@ -302,6 +326,7 @@ export class Graph {
               // Re-pick in case points moved during the hold (simulation may have
               // shifted them under the stationary finger).
               this.findHoveredItem(true)
+              this.requestRender()
               this._shouldSuppressNextClick = true
               this.fireContextMenu(event)
             }, LONG_PRESS_DURATION_MS)
@@ -323,32 +348,42 @@ export class Graph {
         .on('keyup.cosmos', (event) => { if (event.code === 'Space') this.store.isSpaceKeyPressed = false })
 
       this.zoomInstance.behavior
-        .on('start.detect', (e: D3ZoomEvent<HTMLCanvasElement, undefined>) => { this.currentEvent = e })
+        .on('start.detect', (e: D3ZoomEvent<HTMLCanvasElement, undefined>) => {
+          this.currentEvent = e
+          this.requestRender()
+        })
         .on('zoom.detect', (e: D3ZoomEvent<HTMLCanvasElement, undefined>) => {
           const userDriven = !!e.sourceEvent
           if (userDriven) this.updateMousePosition(e.sourceEvent)
           this.currentEvent = e
+          this.requestRender()
         })
         .on('end.detect', (e: D3ZoomEvent<HTMLCanvasElement, undefined>) => {
           this.currentEvent = e
           // Force hover detection on next frame since zoom may have changed what's under the mouse
           this._shouldForceHoverDetection = true
+          this.requestRender()
         })
 
       this.dragInstance.behavior
         .on('start.detect', (e: D3DragEvent<HTMLCanvasElement, undefined, Hovered>) => {
           this.currentEvent = e
           this.updateCanvasCursor()
+          this.requestRender()
         })
         .on('drag.detect', (e: D3DragEvent<HTMLCanvasElement, undefined, Hovered>) => {
           if (this.dragInstance.isActive) {
             this.updateMousePosition(e)
           }
           this.currentEvent = e
+          this.requestRender()
         })
         .on('end.detect', (e: D3DragEvent<HTMLCanvasElement, undefined, Hovered>) => {
           this.currentEvent = e
           this.updateCanvasCursor()
+          // The drag GPU write happens after the draw pass, so the final
+          // position only becomes visible on the frame scheduled here.
+          this.requestRender()
         })
       if (!this.config.enableZoom || !this.config.enableDrag) this.updateZoomDragBehaviors()
       // Zoom level 1 means no zoom (100% scale). defaultConfigValues.initialZoomLevel is undefined,
@@ -603,6 +638,7 @@ export class Graph {
     if (this.ensureDevice(() => this.setImageData(imageDataArray))) return
     this.graph.inputImageData = imageDataArray
     this.points?.createAtlas()
+    this.requestRender()
   }
 
   /**
@@ -855,6 +891,7 @@ export class Graph {
     if (this.ensureDevice(() => this.setPinnedPoints(pinnedIndices))) return
     this.graph.inputPinnedPoints = pinnedIndices && pinnedIndices.length > 0 ? pinnedIndices : undefined
     this.points?.updatePinnedStatus()
+    this.requestRender()
   }
 
   /**
@@ -934,7 +971,7 @@ export class Graph {
     this.transition.start()
     // Re-detect hover on the next frame since data may have changed under a stationary mouse
     this._shouldForceHoverDetection = true
-    this.startFrames()
+    this.requestRender()
 
     this._isFirstRenderAfterInit = false
   }
@@ -1399,7 +1436,8 @@ export class Graph {
     this.store.alpha = alpha
     if (!wasRunning) this.config.onSimulationStart?.()
 
-    // Note: Does NOT start frames - that's handled separately
+    // No-op before the first render() — frame() bails while there's nothing renderable
+    this.requestRender()
   }
 
   /**
@@ -1443,6 +1481,7 @@ export class Graph {
     }
     this.store.isSimulationRunning = true
     this.config.onSimulationUnpause?.()
+    this.requestRender()
   }
 
   /**
@@ -1459,6 +1498,8 @@ export class Graph {
 
     // Run one simulation step, forcing execution regardless of isSimulationRunning
     this.runSimulationStep(true)
+    // A manual step outside the loop is invisible until drawn
+    this.requestRender()
   }
 
   /**
@@ -1472,6 +1513,8 @@ export class Graph {
     window.clearTimeout(this._fitViewOnInitTimeoutID)
     this.cancelLongPress()
     this.stopFrames()
+    this.resizeObserver?.disconnect()
+    this.resizeObserver = undefined
 
     // Remove all event listeners — `.on('.cosmos', null)` clears every handler
     // in the `.cosmos` namespace at once (canvas pointer/click/contextmenu and
@@ -1593,6 +1636,9 @@ export class Graph {
     this.isForceManyBodyUpdateNeeded = false
     this.isForceLinkUpdateNeeded = false
     this.isForceCenterUpdateNeeded = false
+
+    // Public contract: applies data changes without render() — draw them
+    this.requestRender()
   }
 
   /**
@@ -1766,6 +1812,9 @@ export class Graph {
         prevConfig.onLinkMouseOut !== this.config.onLinkMouseOut) {
       this.store.updateLinkHoveringEnabled(this.config)
     }
+
+    // Config changes above apply visual state immediately — draw it
+    this.requestRender()
   }
 
   /**
@@ -2024,26 +2073,78 @@ export class Graph {
   }
 
   /**
-   * The rendering loop - schedules itself to run continuously
+   * Schedules a frame if none is pending. The RAF callback renders once and
+   * reschedules only while `shouldKeepRendering()` — when the scene is static,
+   * no frames run at all.
    */
   private frame (): void {
     if (this._isDestroyed) return
-
-    // Check if simulation should end BEFORE scheduling next frame
-    // This prevents one extra frame from running after simulation ends
-    const { store: { alpha, isSimulationRunning } } = this
-    if (alpha < ALPHA_MIN && isSimulationRunning) {
-      this.end()
-    }
+    if (this.requestAnimationFrameId) return // frame already scheduled
+    // Nothing renderable: before the first render(), or after render() cleared
+    // the data. Without this guard a later pointermove would resurrect drawing
+    // of stale GPU buffers (empty-data render() stops frames but doesn't clear
+    // pointsTextureSize).
+    if (!this.store.pointsTextureSize || (!this.graph.pointsNumber && !this.graph.linksNumber)) return
 
     this.requestAnimationFrameId = window.requestAnimationFrame((now) => {
+      this.requestAnimationFrameId = 0
+
+      // Check if simulation should end BEFORE rendering
+      // This prevents one extra simulation step after alpha decays below ALPHA_MIN
+      const { store: { alpha, isSimulationRunning } } = this
+      if (alpha < ALPHA_MIN && isSimulationRunning) {
+        this.end()
+      }
+
       this.renderFrame(now)
 
-      // Continue the loop (even after simulation ends)
-      if (!this._isDestroyed) {
+      if (!this._isDestroyed && this.shouldKeepRendering()) {
         this.frame()
       }
     })
+  }
+
+  /**
+   * Request a redraw. No-op if a frame is already scheduled. All internal
+   * events that can change visual state funnel through this.
+   */
+  private requestRender (): void {
+    if (this._isDestroyed) return
+    this.frame()
+  }
+
+  /**
+   * Whether the loop must continue past the current frame — true while any
+   * continuous activity can still change visual state.
+   */
+  private shouldKeepRendering (): boolean {
+    // gl-bench derives FPS from frame cadence; keep the loop continuous while
+    // the monitor is shown so its numbers stay meaningful.
+    if (this.fpsMonitor) return true
+    if (this.store.isSimulationRunning) return true // alpha floor handled by end() in frame()
+    // Not isPending: only render()'s transition.start() activates a pending
+    // transition, and render() schedules frames right after — while a
+    // queued-but-never-rendered transition must not keep the loop alive.
+    if (this.transition.isActive) return true
+    if (this.dragInstance.isActive) return true
+    if (this.zoomInstance.isRunning) return true // user gesture or programmatic d3 transition
+    // Right-click repulsion runs regardless of isSimulationRunning (see runSimulationStep)
+    if (this.isRightClickMouse && this.config.enableRightClickRepulsion) return true
+    return this.hasPendingHoverWork()
+  }
+
+  /**
+   * Whether findHoveredItem() still has work to do. Keeps the loop alive
+   * through the hover throttle (up to MAX_HOVER_DETECTION_DELAY frames) until
+   * detection actually executes — which updates _lastCheckedMouseX/Y and
+   * consumes _shouldForceHoverDetection, turning this false.
+   */
+  private hasPendingHoverWork (): boolean {
+    if (!this._isPointerOnCanvas) return false
+    if (this._shouldForceHoverDetection) return true
+    const deltaX = Math.abs(this._lastMouseX - this._lastCheckedMouseX)
+    const deltaY = Math.abs(this._lastMouseY - this._lastCheckedMouseY)
+    return deltaX > MIN_MOUSE_MOVEMENT_THRESHOLD || deltaY > MIN_MOUSE_MOVEMENT_THRESHOLD
   }
 
   /**
@@ -2131,15 +2232,6 @@ export class Graph {
       window.cancelAnimationFrame(this.requestAnimationFrameId)
       this.requestAnimationFrameId = 0 // Reset to 0
     }
-  }
-
-  /**
-   * Starts continuous rendering
-   */
-  private startFrames (): void {
-    if (this._isDestroyed) return
-    this.stopFrames() // Stop any existing rendering
-    this.frame() // Start the loop
   }
 
   /**

--- a/src/stories/experiments.stories.ts
+++ b/src/stories/experiments.stories.ts
@@ -4,15 +4,17 @@ import { createStory, Story } from '@/graph/stories/create-story'
 import { CosmosStoryProps } from './create-cosmos'
 import { meshWithHoles } from './experiments/mesh-with-holes'
 import { fullMesh } from './experiments/full-mesh'
+import { onDemandRendering } from './experiments/on-demand-rendering'
 
 import createCosmosRaw from './create-cosmos?raw'
 import generateMeshDataRaw from './generate-mesh-data?raw'
 import meshWithHolesRaw from './experiments/mesh-with-holes?raw'
 import fullMeshRaw from './experiments/full-mesh?raw'
+import onDemandRenderingRaw from './experiments/on-demand-rendering?raw'
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta: Meta<CosmosStoryProps> = {
-  title: 'Examples/Experiments',
+  title: 'Examples/Misc',
 }
 
 const sourceCodeAddonParams = [
@@ -34,6 +36,15 @@ export const MeshWithHoles: Story = {
   parameters: {
     sourceCode: [
       { name: 'Story', code: meshWithHolesRaw },
+      ...sourceCodeAddonParams,
+    ],
+  },
+}
+export const OnDemandRendering: Story = {
+  ...createStory(onDemandRendering),
+  parameters: {
+    sourceCode: [
+      { name: 'Story', code: onDemandRenderingRaw },
       ...sourceCodeAddonParams,
     ],
   },

--- a/src/stories/experiments/on-demand-rendering.ts
+++ b/src/stories/experiments/on-demand-rendering.ts
@@ -1,0 +1,57 @@
+import { Graph } from '@cosmos.gl/graph'
+import { createCosmos } from '../create-cosmos'
+import { generateMeshData } from '../generate-mesh-data'
+
+/**
+ * cosmos.gl renders on demand: frames run only while something visual can
+ * change (simulation, transitions, zoom, drag, hover, resize) and stop
+ * entirely when the scene is static. This story overlays a frame counter so
+ * you can watch rendering go idle after the simulation decays, and resume on
+ * hover, zoom, pan, drag, or window resize.
+ */
+export const onDemandRendering = (): { graph: Graph; div: HTMLDivElement; destroy?: () => void } => {
+  // Count requestAnimationFrame callbacks to visualize when cosmos.gl actually
+  // renders. Patched before the graph is created so its frames are counted.
+  let frameCount = 0
+  const originalRequestAnimationFrame = window.requestAnimationFrame.bind(window)
+  window.requestAnimationFrame = (callback: FrameRequestCallback): number =>
+    originalRequestAnimationFrame((now) => {
+      frameCount += 1
+      callback(now)
+    })
+
+  const { pointPositions, links, pointColors } = generateMeshData(40, 30, 15, 1.0)
+  const { div, graph, destroy } = createCosmos({
+    pointPositions,
+    links,
+    pointColors,
+    // Let the simulation actually end — the shared story config uses a decay
+    // so large the simulation would run (and render) practically forever.
+    simulationDecay: 1000,
+  })
+
+  const counter = document.createElement('div')
+  counter.style.cssText = 'position:absolute;top:16px;left:16px;padding:8px 12px;font:12px monospace;' +
+    'color:#fff;background:rgba(0,0,0,0.6);border-radius:4px;pointer-events:none;z-index:1'
+  div.style.position = 'relative'
+  div.appendChild(counter)
+
+  // The overlay updates on an interval timer (not requestAnimationFrame) so it
+  // keeps reporting while cosmos.gl is idle and renders nothing.
+  let lastCount = 0
+  const intervalId = window.setInterval(() => {
+    const framesPerSecond = (frameCount - lastCount) * 2
+    lastCount = frameCount
+    counter.textContent = `frames rendered: ${frameCount} (${framesPerSecond}/s) — ${framesPerSecond === 0 ? 'idle' : 'rendering'}`
+  }, 500)
+
+  return {
+    div,
+    graph,
+    destroy: (): void => {
+      window.clearInterval(intervalId)
+      window.requestAnimationFrame = originalRequestAnimationFrame
+      destroy?.()
+    },
+  }
+}


### PR DESCRIPTION
## What

Rendering is now on-demand: `requestAnimationFrame` frames run only while something visual can change, and stop entirely when the scene is static. Previously the frame loop re-scheduled itself unconditionally forever, burning GPU/CPU/battery on idle graphs.

## How

`frame()` is now an idempotent scheduler; after each rendered frame the loop continues only while `shouldKeepRendering()` is true:

- simulation running (alpha floor handled by `end()` as before)
- a transition animating (`transition.isActive`)
- drag in progress
- zoom in progress (user gesture or programmatic d3 transition)
- right-click repulsion held — it runs regardless of `isSimulationRunning`
- pending hover work — keeps the loop alive through the 4-frame hover throttle until `findHoveredItem()` actually executes, so hover never goes stale
- FPS monitor shown (`showFPSMonitor: true`) — keeps the loop continuous so gl-bench numbers stay meaningful; doubles as a debug escape hatch

Every event that can change visuals schedules a frame via a new private `requestRender()`: pointer enter/move/leave/down, zoom and drag `.detect` handlers (programmatic zoom needs no extra bookkeeping — d3 transitions fire zoom events every frame), `setConfig`/`setConfigPartial`, `start()`/`unpause()`/`step()`, `create()`, `setImageData`, `setPinnedPoints`, and `render()`.

Two silent dependencies on the continuous loop are handled explicitly:

- **Canvas resize** was detected by per-frame polling; ~~a `ResizeObserver` on the canvas now schedules a redraw (the actual work stays in the in-frame `resizeCanvas()`).~~ a `ResizeObserver` now flags the change (`_shouldSyncScreenSize`) and wakes the loop; the frame applies it via `syncScreenSize()` (renamed from `resizeCanvas` — it never touched the drawing buffer, which luma.gl owns). Per-frame size checking survives only as a fallback for environments without `ResizeObserver`, where the loop also stays continuous so detection keeps working.
- **Drag release**: the drag GPU write happens *after* the draw pass, so the drag `end.detect` hook schedules one extra frame to make the final position visible.

A guard in `frame()` also prevents a stray pointermove from resurrecting drawing of stale GPU buffers after `render()` was called with empty data.

No API or config changes. Data setters keep their existing contract (dirty flags applied on `render()`/`create()`).

## Docs & examples

- New Storybook story ~~`Examples/Experiments → On Demand Rendering`~~ `Examples/Misc → On Demand Rendering` with a frame-counter overlay showing rendering going idle after the simulation decays and resuming on hover/zoom/drag/resize. The former `Examples/Experiments` group (FullMesh, MeshWithHoles) is renamed to `Examples/Misc` as part of this change.
- ~~`migration-notes.md` entry describing the behavioral change.~~ (not needed — no breaking changes; behavior notes live in the history entry)

## Post-review updates

- **Rebased onto v3.3 main** — one conflict (this PR's `ResizeObserver` and the luma-9.3 first-measurement await landed in the same setup block); kept both, they do different jobs.
- **Screen-size sync compacted** — the observer now carries the information as well as waking the loop (see the updated resize bullet above); the per-frame `clientWidth` reads (forced-layout hazards) are gone from the render path.
- **Observer-less environments keep the old behavior** — `shouldKeepRendering()` returns true when no `ResizeObserver` exists, so those environments never idle and per-frame size checking still catches resizes.
- **Verified**: loop idles at a stable frame count, wakes on hover/zoom, re-idles; resize-while-idle costs exactly two frames; removal transitions run to completion; `setConfig` changes render from idle; an exhaustive sweep of every pixel-mutating public API found no path that fails to schedule a frame.

## Testing

- `npm run lint` — clean (only two pre-existing `max-len` warnings in untouched data files)
- `npm run build` — ES + UMD build pass
- Manual Storybook verification recommended: watch the new story's frame counter go idle after simulation decay and resume on each interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-demand redraw scheduling so the graph renders only when active work is happening (interactions, simulation, transitions, gestures).
  * Improved canvas resizing using observer-based syncing when available.
  * Added a Storybook experiment demo with an on-screen counter showing render activity.
* **Bug Fixes**
  * Ensured redraws happen immediately after key user actions and state changes (hover, picking, gestures, data/config updates, lifecycle actions).
  * Updated cleanup to disconnect resize observation to prevent leaks.
* **Documentation**
  * Added/updated a guide explaining redraw triggers and behavior.
* **Chores**
  * Reorganized experiment stories and added the new on-demand rendering story.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->