### PR TITLE
Make pre-commit hook and ESLint work in git worktrees

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "storybook",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-lc", "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use 22 && npx storybook dev -p 6006 --ci"],
+      "port": 6006
+    }
+  ]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "extends": [
     "plugin:@typescript-eslint/recommended",
     "standard"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Version-controlled pre-commit hook.
+#
+# Enabled via `git config core.hooksPath .githooks` (set automatically by the
+# `prepare` npm script). Because it lives in the tracked tree it is present in
+# every worktree, and because it resolves the toolchain from the nearest
+# node_modules ABOVE the working tree, it also works from git worktrees that have
+# no node_modules of their own — they share the parent checkout's dependencies.
+# (The old .git/hooks/pre-commit hardcoded ./node_modules, which a fresh worktree
+# doesn't have, so commits failed there until you ran `npm install` by hand.)
+set -e
+
+# lint-staged and eslint need a modern Node (>= 18, per package.json "engines").
+# Fail with a clear, actionable message instead of a cryptic runtime SyntaxError
+# when a commit is triggered from a shell/IDE where an old Node is still on PATH
+# (e.g. the default before `nvm use`).
+if ! command -v node >/dev/null 2>&1; then
+  echo "pre-commit: 'node' not found on PATH. If you use nvm, run 'nvm use' before committing." >&2
+  exit 1
+fi
+node_major="$(node -v | sed 's/^v\([0-9]*\).*/\1/')"
+if [ "$node_major" -lt 18 ]; then
+  echo "pre-commit: Node $(node -v) is too old for lint-staged/eslint (need >= 18)." >&2
+  echo "            If you use nvm, run 'nvm use' (or set a newer default) before committing." >&2
+  exit 1
+fi
+
+# Walk up from the working-tree root to the first node_modules that has lint-staged.
+dir="$(pwd)"
+while [ "$dir" != "/" ] && [ ! -x "$dir/node_modules/.bin/lint-staged" ]; do
+  dir="$(dirname "$dir")"
+done
+
+if [ ! -x "$dir/node_modules/.bin/lint-staged" ]; then
+  echo "pre-commit: lint-staged not found — run 'npm install' in this repo." >&2
+  exit 1
+fi
+
+# Run from the current working tree so staged files and package.json resolve
+# against this worktree, using the toolchain found above.
+exec "$dir/node_modules/.bin/lint-staged"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,15 @@ contribution process, see `CONTRIBUTING.md`, `CHARTER.md`, `CODE_OF_CONDUCT.md`,
   `configuration.mdx` / `api-reference.mdx` docs — the best worked examples of building the input arrays.
 - `helper.ts` — utilities (e.g. `getRgbaColor`: parse a CSS/hex color into a normalized RGBA tuple).
 
-`migration-notes.md` is the authoritative history of data-format and config changes (v1→v3: the move to
-`Float32Array` ingest, the v3 config renames, RGBA normalized to 0..1). Read it before touching the
-public API or config keys.
+`migration-notes.md` documents **breaking changes only** — data-format and config changes that require
+users to update their code (v1→v3: the move to `Float32Array` ingest, the v3 config renames, RGBA
+normalized to 0..1). Read it before touching the public API or config keys. Do **not** add an entry here
+for non-breaking work (new features, internal rewrites, backward-compatible additions) — that goes in
+`history/` instead.
+
+`history/` is the running log of **why** changes happened (intent and tradeoffs; git records the *what*).
+Entries live at `history/YYYY/YYYY-MM-DD-topic.md`; see `history/PROMPT.md` for the format, or run the
+`history` skill (`/history <why>`), which drafts one.
 
 ## Data model in one paragraph
 
@@ -56,7 +62,8 @@ example if you changed behavior/config/public API, then open a PR. Contributions
 
 ## Commits
 
-Sign off every commit: `git commit -s` (adds the `Signed-off-by` trailer). The repo enforces **DCO**
+Sign off every commit: `git commit -s` (adds the `Signed-off-by` trailer). When amending or rebasing
+existing commits, `git rebase --signoff <base>` adds it to each. The repo enforces **DCO**
 (`.github/dco.yml`) and rejects unsigned commits from non-members. AI/tool-assisted commits also
 carry a `Co-authored-by:` trailer (see the log).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
         "eslint-plugin-storybook": "^0.11.1",
         "eslint-plugin-unicorn": "^43.0.1",
         "lint-staged": "^13.0.3",
-        "pre-commit": "^1.2.2",
         "remark-gfm": "^4.0.0",
         "storybook": "^8.4.5",
         "typescript": "^5.9.3",
@@ -1131,9 +1130,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1148,9 +1144,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1165,9 +1158,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1182,9 +1172,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1199,9 +1186,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1216,9 +1200,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1233,9 +1214,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1250,9 +1228,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1267,9 +1242,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1284,9 +1256,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1301,9 +1270,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1318,9 +1284,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1335,9 +1298,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3589,13 +3549,6 @@
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
       "dev": true
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/builtin-modules": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
@@ -3855,34 +3808,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6345,13 +6275,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -7923,15 +7846,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-shim": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -8190,78 +8104,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/pre-commit": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
-      "integrity": "sha512-qokTiqxD6GjODy5ETAIgzsRgnBWWQHQH2ghy86PU7mIn/wuWeTwF3otyNQZxWBwVn8XNr8Tdzj/QfUXpH+gRZA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "cross-spawn": "^5.0.1",
-        "spawn-sync": "^1.0.15",
-        "which": "1.2.x"
-      }
-    },
-    "node_modules/pre-commit/node_modules/cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
-    "node_modules/pre-commit/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/pre-commit/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-commit/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pre-commit/node_modules/which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha512-16uPglFkRPzgiUXYMi1Jf8Z5EzN1iB4V0ZtMXcHZnwsBtQhhHeCqoWw7tsUY42hJGNDWtUsVLTjakIa5BgAxCw==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/pre-commit/node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-      "dev": true
-    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -8297,19 +8139,6 @@
       "engines": {
         "node": ">= 0.6.0"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "dev": true
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -8452,22 +8281,6 @@
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/recast": {
@@ -8769,13 +8582,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/safe-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
@@ -9005,17 +8811,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/spawn-sync": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "concat-stream": "^1.4.7",
-        "os-shim": "^0.1.2"
-      }
-    },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -9091,16 +8886,6 @@
         "prettier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-argv": {
@@ -9436,13 +9221,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -9622,7 +9400,8 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/uuid": {
       "version": "9.0.1",
@@ -12382,12 +12161,6 @@
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
       "dev": true
     },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
-    },
     "builtin-modules": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
@@ -12571,28 +12344,10 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cross-spawn": {
@@ -14287,12 +14042,6 @@
         "is-docker": "^2.0.0"
       }
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -15362,12 +15111,6 @@
         }
       }
     },
-    "os-shim": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
-      "dev": true
-    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -15531,70 +15274,6 @@
         "source-map-js": "^1.2.1"
       }
     },
-    "pre-commit": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
-      "integrity": "sha512-qokTiqxD6GjODy5ETAIgzsRgnBWWQHQH2ghy86PU7mIn/wuWeTwF3otyNQZxWBwVn8XNr8Tdzj/QfUXpH+gRZA==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^5.0.1",
-        "spawn-sync": "^1.0.15",
-        "which": "1.2.x"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-          "dev": true
-        },
-        "which": {
-          "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha512-16uPglFkRPzgiUXYMi1Jf8Z5EzN1iB4V0ZtMXcHZnwsBtQhhHeCqoWw7tsUY42hJGNDWtUsVLTjakIa5BgAxCw==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-          "dev": true
-        }
-      }
-    },
     "pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -15618,18 +15297,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "dev": true
     },
     "punycode": {
@@ -15723,21 +15390,6 @@
         "find-up": "^4.1.0",
         "read-pkg": "^5.2.0",
         "type-fest": "^0.8.1"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
       }
     },
     "recast": {
@@ -15947,12 +15599,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
     "safe-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
@@ -16112,16 +15758,6 @@
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true
     },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
-      "dev": true,
-      "requires": {
-        "concat-stream": "^1.4.7",
-        "os-shim": "^0.1.2"
-      }
-    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -16174,15 +15810,6 @@
       "dev": true,
       "requires": {
         "@storybook/core": "8.6.17"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "string-argv": {
@@ -16416,12 +16043,6 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
     "typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -16558,7 +16179,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "uuid": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "CITATION.cff"
   ],
   "scripts": {
-    "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && (git config core.hooksPath .githooks || echo \"prepare: warning: could not set core.hooksPath -- pre-commit hooks will not run. Run 'git config core.hooksPath .githooks' manually.\" 1>&2) || true",
+    "prepare": "sh scripts/prepare.sh",
     "build": "vite build --mode es && vite build --mode umd",
     "watch": "vite build --watch",
     "lint": "eslint --cache ./src --ext .ts --ignore-path .gitignore",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "CITATION.cff"
   ],
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks || true",
     "build": "vite build --mode es && vite build --mode umd",
     "watch": "vite build --watch",
     "lint": "eslint --cache ./src --ext .ts --ignore-path .gitignore",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "CITATION.cff"
   ],
   "scripts": {
-    "prepare": "git config core.hooksPath .githooks || true",
+    "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && (git config core.hooksPath .githooks || echo \"prepare: warning: could not set core.hooksPath -- pre-commit hooks will not run. Run 'git config core.hooksPath .githooks' manually.\" 1>&2) || true",
     "build": "vite build --mode es && vite build --mode umd",
     "watch": "vite build --watch",
     "lint": "eslint --cache ./src --ext .ts --ignore-path .gitignore",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "eslint-plugin-storybook": "^0.11.1",
     "eslint-plugin-unicorn": "^43.0.1",
     "lint-staged": "^13.0.3",
-    "pre-commit": "^1.2.2",
     "remark-gfm": "^4.0.0",
     "storybook": "^8.4.5",
     "typescript": "^5.9.3",
@@ -89,7 +88,6 @@
     "gl-matrix": "^3.4.3",
     "random": "^4.1.0"
   },
-  "pre-commit": "lint:staged",
   "lint-staged": {
     "*.{js,ts}": "eslint --quiet --cache --fix --ignore-pattern 'docs/**'"
   },

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -11,7 +11,7 @@
 # to support (see .githooks/pre-commit).
 set -e
 
-if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" != "true" ]; then
   exit 0
 fi
 

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Configures core.hooksPath so .githooks/pre-commit runs for this checkout.
+#
+# Run via the "prepare" npm script on every `npm install`/`npm ci`. Silently
+# does nothing when there's no git working tree to configure (e.g. this
+# package installed as a registry/tarball dependency elsewhere) -- but if we
+# ARE inside a real working tree and the config write itself fails
+# (permissions, git missing, a corrupted repo), that's a real problem and
+# gets a warning instead of vanishing silently, so hooks don't end up quietly
+# unconfigured in exactly the git-worktree scenario this hooks setup exists
+# to support (see .githooks/pre-commit).
+set -e
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! git config core.hooksPath .githooks; then
+  echo "prepare: warning: could not set core.hooksPath -- pre-commit hooks will not run. Run 'git config core.hooksPath .githooks' manually." >&2
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Fixes two issues that broke committing and linting from **git worktrees** nested inside the repo (e.g. `.claude/worktrees/…`), plus a related hardening.

- **Pre-commit hook in worktrees.** Moved the hook into a version-controlled `.githooks/` directory enabled via `core.hooksPath` (set by the `prepare` npm script). It's now present in every worktree and resolves `lint-staged` from the nearest `node_modules` *above* the working tree, so a worktree sharing the parent checkout's dependencies commits fine. The old `.git/hooks/pre-commit` hardcoded `./node_modules`, which a fresh worktree doesn't have.
- **ESLint "couldn't determine the plugin 'import' uniquely".** Added `"root": true` to `.eslintrc`. Without it, linting a file inside a nested worktree loaded **both** the worktree's and the parent repo's `.eslintrc`, resolving the `import`/`unicorn` plugins to two different `node_modules` — which failed *only after* the worktree had its own `npm install`. `root: true` stops the config cascade at the repo root.
- **Node version guard.** The hook now fails with a clear, actionable message when an old Node is on `PATH` (e.g. before `nvm use`) instead of a cryptic `lint-staged` `SyntaxError`.
- **Docs.** AGENTS.md now routes non-breaking "why" notes to `history/` (migration-notes.md = breaking only) and requires a `Signed-off-by` trailer on commits.
- Adds a Storybook launch config for Claude Code preview tooling.

## Post-review hardening

Follow-ups from review, all in the `prepare` script that wires up `core.hooksPath`:

- **Removed the old `pre-commit` npm package.** It auto-wrote `.git/hooks/pre-commit` on every `npm install` — the exact hardcoded-`./node_modules` hook this PR's `.githooks/pre-commit` replaces. `core.hooksPath` makes git ignore that file once set, but leaving the package installed kept regenerating a now-inert hook that could mislead a contributor debugging why linting didn't run. `lint:staged` (the npm script it invoked) stays, still runnable by hand.
- **`prepare` no longer silently swallows a real hooksPath failure.** The original `git config core.hooksPath .githooks || true` masked two different situations identically: legitimately having no `.git` at all (fine to skip — e.g. installed as a registry dependency) and being inside a real working tree where the config write itself fails (permissions, git missing, a corrupted repo). The second case defeated the point of this PR — hooks would end up silently unconfigured in exactly the worktree scenario it exists to fix. Now: skip silently only when there's genuinely no git working tree; otherwise, a failed `git config` prints an actionable warning instead of vanishing. `npm install` still isn't blocked by it.
- **Checks rev-parse's actual output, not just its exit code.** `git rev-parse --is-inside-work-tree` exits `0` and prints `false` in two more states: inside a bare clone, or inside a repo's own `.git/` directory. The exit-code-only check misread both as "yes, configure hooks." Now compares the output against the literal string `true`.
- **Extracted the inline shell into `scripts/prepare.sh`.** The logic above had grown into a single long escaped-quotes line inside `package.json` — hard to read and diff. Now a standalone POSIX script (matching how `.githooks/pre-commit` already lives as a tracked file), invoked as `sh scripts/prepare.sh`.

## Test plan

Verified in a throwaway worktree under `.claude/worktrees/`:

- ✅ New worktree inherits `core.hooksPath`; hook finds `lint-staged` via parent `node_modules` with **no** local install.
- ✅ Reproduced the `import` plugin error after `npm install` in the worktree, then confirmed `root: true` fixes it.
- ✅ Committing a new Storybook story succeeds; committing code with a real lint error (`no-explicit-any`) is **blocked**.
- ✅ Node guard: exits with a clear message under Node 12, no-op under Node 22.
- ✅ `npm run lint` on the main checkout passes (0 errors).
- ✅ Removing the `pre-commit` package: a fresh worktree still commits cleanly through `.githooks/pre-commit` with the package gone (found via the parent `node_modules`, as before); `package-lock.json` confirmed clean of it.
- ✅ `prepare` hardening: tested all three shell paths directly — normal repo (silent success), outside any repo (silent skip), and a forced `git config` failure inside a real working tree (warning printed, `npm install` still exits 0).
- ✅ rev-parse output check: verified all five reachable states, including the two the fix targets — run from inside `.git/` and from inside a bare clone (`git clone --bare`), both now correctly skip instead of misconfiguring; confirmed via a control run that the old exit-code-only check would have misconfigured the `.git/`-dir case.
- ✅ `scripts/prepare.sh` extraction: identical behavior re-verified end to end via `npm run prepare` in a fresh worktree.

> [!NOTE]
> `.githooks/` must be committed (done here) for worktrees to pick it up — until then `core.hooksPath` points at a nonexistent dir and commits run no hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automatically configures local git hooks during install by setting the repo’s hook path.
  * Adds a pre-commit hook that requires Node major version **≥ 18** and runs staged-file linting.
  * Adds a Storybook CI-style debug configuration running on **port 6006**.
* **Documentation**
  * Clarifies when to use `history/` vs `migration-notes.md`, including the required entry format.
  * Expands contributor sign-off guidance for amend/rebase and reiterates DCO enforcement.
* **Bug Fixes**
  * Updates ESLint configuration to treat it as the root to prevent inheriting parent settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
